### PR TITLE
Add module compare

### DIFF
--- a/pymongo_schema/compare.py
+++ b/pymongo_schema/compare.py
@@ -1,0 +1,72 @@
+# coding: utf8
+"""
+This module intends to compare two mongo schemas (from extract module)
+"""
+
+
+def compare_schemas_bases(schema, exp_schema, hierarchy=''):
+    """
+    Recursively compare the base structure of two schemas.
+
+    The base structure compared is:
+    - fields (or collection or database) names
+    - fields type (keys 'type' and 'array_type')
+
+    It displays only the first difference.
+    If a field appears in one schema but not in the other,
+    the field is displayed but not its entire data.
+
+    example:
+    with inputs:
+    schema = {'db': {'coll': {'object': {'field1': {'type': 'string'}}}}}
+    exp_schema = {'db': {'coll': {'object': {'field1': {'type': 'integer'}}}}}
+
+    result will be:
+    [{'hierarchy': 'db.coll',
+      'schema': {'field1': {'type': 'string'}},
+      'exp_schema': {'field1': {'type': 'integer'}}}]
+
+    :param schema: dict - schema to be compared
+    :param exp_schema: dict - schema to compare to
+    :param hierarchy: string - describe level of recursion (keep tracks of previous levels)
+    :return: list of dicts describing differences
+                [{'hierarchy': db_name.coll_name,
+                  'schema': differing_value_in_schema,
+                  'expected': differing_value_in_exp_schema}]
+    """
+    diff = []
+
+    additional_fields = set(schema) - set(exp_schema)
+    missing_fields = set(exp_schema) - set(schema)
+
+    # manage additional / missing fields
+    for field in additional_fields:
+        diff.append({'hierarchy': hierarchy, 'schema': field, 'expected': None})
+    for field in missing_fields:
+        diff.append({'hierarchy': hierarchy, 'schema': None, 'expected': field})
+
+    # manage differences
+    for field in sorted(set(schema) & set(exp_schema)):
+        # manage initial case: field is db name and values are collections (not fields yet)
+
+        if not hierarchy:
+            diff += compare_schemas_bases(schema[field], exp_schema[field], hierarchy=field)
+
+        # manage regular case (differences of fields type)
+        if schema[field].get('type') != exp_schema[field].get('type'):
+            diff.append({'hierarchy': '{}.{}'.format(hierarchy, field),
+                         'schema': {'type': schema[field]['type']},
+                         'expected': {'type': exp_schema[field]['type']}})
+
+        # manage array case (differences of fields array_type) only if both types are ARRAY
+        elif schema[field].get('array_type') != exp_schema[field].get('array_type'):
+            diff.append({'hierarchy': '{}.{}'.format(hierarchy, field),
+                         'schema': {'array_type': schema[field]['array_type']},
+                         'expected': {'array_type': exp_schema[field]['array_type']}})
+
+        # recursion in case of nested object
+        if 'object' in schema[field] and 'object' in exp_schema[field]:
+            diff += compare_schemas_bases(schema[field]['object'],
+                                          exp_schema[field]['object'],
+                                          hierarchy='{}.{}'.format(hierarchy, field))
+    return diff

--- a/pymongo_schema/compare.py
+++ b/pymongo_schema/compare.py
@@ -73,7 +73,20 @@ def compare_schemas_bases(prev_schema, new_schema, hierarchy=''):
 
 
 def is_retrocompatible(diff):
+    """
+    Determine whether diff between schema is retrocompatible (won't break the process).
+
+    It is considered retrocompatible if:
+    - a field (or collection or database) has been added
+
+    It is considered NOT retrocompatible if:
+    - a field (or collection or database) has been removed
+    - a field has been modified
+
+    :param diff: list of dicts containing differences between two schemas (compare_schemas_bases)
+    :return: boolean
+    """
     for line in diff:
-        if line['prev_schema'] is not None and line['new_schema'] is not None:
+        if line['prev_schema'] is not None:
             return False
     return True

--- a/pymongo_schema/compare.py
+++ b/pymongo_schema/compare.py
@@ -4,7 +4,7 @@ This module intends to compare two mongo schemas (from extract module)
 """
 
 
-def compare_schemas_bases(schema, exp_schema, hierarchy=''):
+def compare_schemas_bases(prev_schema, new_schema, hierarchy=''):
     """
     Recursively compare the base structure of two schemas.
 
@@ -18,62 +18,62 @@ def compare_schemas_bases(schema, exp_schema, hierarchy=''):
 
     example:
     with inputs:
-    schema = {'db': {'coll': {'object': {'field1': {'type': 'string'}}}}}
-    exp_schema = {'db': {'coll': {'object': {'field1': {'type': 'integer'}}}}}
+    prev_schema = {'db': {'coll': {'object': {'field1': {'type': 'string'}}}}}
+    new_schema = {'db': {'coll': {'object': {'field1': {'type': 'integer'}}}}}
 
     result will be:
     [{'hierarchy': 'db.coll',
-      'schema': {'field1': {'type': 'string'}},
-      'exp_schema': {'field1': {'type': 'integer'}}}]
+      'prev_schema': {'field1': {'type': 'string'}},
+      'new_schema': {'field1': {'type': 'integer'}}}]
 
-    :param schema: dict - schema to be compared
-    :param exp_schema: dict - schema to compare to
+    :param prev_schema: dict - previous schema to compare to
+    :param new_schema: dict - new schema to be compared
     :param hierarchy: string - describe level of recursion (keep tracks of previous levels)
     :return: list of dicts describing differences
                 [{'hierarchy': db_name.coll_name,
-                  'schema': differing_value_in_schema,
-                  'expected': differing_value_in_exp_schema}]
+                  'prev_schema': differing_value_in_prev_schema,
+                  'new_schema': differing_value_in_new_schema}]
     """
     diff = []
 
-    additional_fields = set(schema) - set(exp_schema)
-    missing_fields = set(exp_schema) - set(schema)
+    additional_fields = set(new_schema) - set(prev_schema)
+    missing_fields = set(prev_schema) - set(new_schema)
 
     # manage additional / missing fields
-    for field in additional_fields:
-        diff.append({'hierarchy': hierarchy, 'schema': field, 'expected': None})
     for field in missing_fields:
-        diff.append({'hierarchy': hierarchy, 'schema': None, 'expected': field})
+        diff.append({'hierarchy': hierarchy, 'prev_schema': field, 'new_schema': None})
+    for field in additional_fields:
+        diff.append({'hierarchy': hierarchy, 'prev_schema': None, 'new_schema': field})
 
     # manage differences
-    for field in sorted(set(schema) & set(exp_schema)):
+    for field in sorted(set(prev_schema) & set(new_schema)):
         # manage initial case: field is db name and values are collections (not fields yet)
 
         if not hierarchy:
-            diff += compare_schemas_bases(schema[field], exp_schema[field], hierarchy=field)
+            diff += compare_schemas_bases(prev_schema[field], new_schema[field], hierarchy=field)
 
         # manage regular case (differences of fields type)
-        if schema[field].get('type') != exp_schema[field].get('type'):
+        if prev_schema[field].get('type') != new_schema[field].get('type'):
             diff.append({'hierarchy': '{}.{}'.format(hierarchy, field),
-                         'schema': {'type': schema[field]['type']},
-                         'expected': {'type': exp_schema[field]['type']}})
+                         'prev_schema': {'type': prev_schema[field]['type']},
+                         'new_schema': {'type': new_schema[field]['type']}})
 
         # manage array case (differences of fields array_type) only if both types are ARRAY
-        elif schema[field].get('array_type') != exp_schema[field].get('array_type'):
+        elif prev_schema[field].get('array_type') != new_schema[field].get('array_type'):
             diff.append({'hierarchy': '{}.{}'.format(hierarchy, field),
-                         'schema': {'array_type': schema[field]['array_type']},
-                         'expected': {'array_type': exp_schema[field]['array_type']}})
+                         'prev_schema': {'array_type': prev_schema[field]['array_type']},
+                         'new_schema': {'array_type': new_schema[field]['array_type']}})
 
         # recursion in case of nested object
-        if 'object' in schema[field] and 'object' in exp_schema[field]:
-            diff += compare_schemas_bases(schema[field]['object'],
-                                          exp_schema[field]['object'],
+        if 'object' in prev_schema[field] and 'object' in new_schema[field]:
+            diff += compare_schemas_bases(prev_schema[field]['object'],
+                                          new_schema[field]['object'],
                                           hierarchy='{}.{}'.format(hierarchy, field))
     return diff
 
 
 def is_retrocompatible(diff):
     for line in diff:
-        if line['schema'] is not None and line['expected'] is not None:
+        if line['prev_schema'] is not None and line['new_schema'] is not None:
             return False
     return True

--- a/pymongo_schema/compare.py
+++ b/pymongo_schema/compare.py
@@ -70,3 +70,10 @@ def compare_schemas_bases(schema, exp_schema, hierarchy=''):
                                           exp_schema[field]['object'],
                                           hierarchy='{}.{}'.format(hierarchy, field))
     return diff
+
+
+def is_retrocompatible(diff):
+    for line in diff:
+        if line['schema'] is not None and line['expected'] is not None:
+            return False
+    return True

--- a/pymongo_schema/export.py
+++ b/pymongo_schema/export.py
@@ -417,10 +417,12 @@ class TxtOutput(ListOutput):
         pd.options.display.max_colwidth = 1000
         formatters = dict()
         for col in self.data_df.columns:
+            # calculate columns length: max len of its elements
             col_len = self.data_df[col].map(
                 lambda s: len(s) if isinstance(s, basestring) else len(str(s))).max()
-            formatters[col] = u'{{:<{}}}'.format(col_len + 3).format
-
+            # prepare a method to apply on each element of the column so they have the same length
+            formatters[col] = partial(
+                lambda x, y: u'{{:<{}}}'.format(y + 3).format(u'{}'.format(x)), y=col_len)
         output_str = ''
         for db in self.data_df.Database.unique():
             output_str += '\n### Database: {}\n'.format(db)
@@ -510,7 +512,8 @@ class MdOutput(ListOutput):
             col_length = columns_length[columns.index(col_name)]
             if repeat:
                 return value * col_length
-            return u'{{:<{}}}'.format(col_length).format(value if value is not None else str(value))
+            return u'{{:<{}}}'.format(col_length).format(
+                u'{}'.format(value if value is not None else str(value)))
 
         str_column_names = self._make_line([format_column(col, col) for col in columns])
         str_sep_header = self._make_line([format_column(col, '-', repeat=True) for col in columns])

--- a/pymongo_schema/export.py
+++ b/pymongo_schema/export.py
@@ -158,19 +158,19 @@ class _DiffPreProcessing(OutputPreProcessing):
         table = []
         for d in data:
             if not d['hierarchy']:
-                db = d['schema'] or d['expected']
+                db = d['prev_schema'] or d['new_schema']
                 coll = ''
                 hierarchy = []
             else:
                 hierarchy = d['hierarchy'].split('.')
                 db = hierarchy.pop(0)
                 if not hierarchy:
-                    coll = d['schema'] or d['expected']
+                    coll = d['prev_schema'] or d['new_schema']
                 else:
                     coll = hierarchy.pop(0)
-            table.append([db, coll, '.'.join(hierarchy), d['schema'], d['expected']])
+            table.append([db, coll, '.'.join(hierarchy), d['prev_schema'], d['new_schema']])
 
-        header = ['Database', 'Collection', 'Hierarchy', 'In Schema', 'In Expected']
+        header = ['Database', 'Collection', 'Hierarchy', 'Previous Schema', 'New Schema']
         return pd.DataFrame(table, columns=header)
 
 

--- a/pymongo_schema/export.py
+++ b/pymongo_schema/export.py
@@ -356,7 +356,8 @@ class TxtOutput(ListOutput):
             output_str += '\n### Database: {}\n'.format(db)
             df_db = self.mongo_schema_df.query('Database == @db').iloc[:, 1:]
             for col in df_db.Collection.unique():
-                output_str += '--- Collection: {} \n'.format(col)
+                if col:
+                    output_str += '--- Collection: {} \n'.format(col)
                 df_col = df_db.query('Collection == @col').iloc[:, 1:]
                 output_str += df_col.to_string(index=False, formatters=formatters, justify='left',
                                                float_format=lambda x: '%.2f' % x)
@@ -448,7 +449,8 @@ class MdOutput(ListOutput):
             output_str.append('\n### Database: {}\n'.format(db))
             df_db = self.mongo_schema_df.query('Database == @db').iloc[:, 1:]
             for col in df_db.Collection.unique():
-                output_str.append('#### Collection: {} \n'.format(col))
+                if col:
+                    output_str.append('#### Collection: {} \n'.format(col))
                 df_col = df_db.query('Collection == @col').iloc[:, 1:]
                 output_str.append("\n".join([str_column_names, str_sep_header] +
                                             [self._make_line([format_column(columns[i], value)

--- a/pymongo_schema/export.py
+++ b/pymongo_schema/export.py
@@ -154,7 +154,7 @@ class _DiffPreProcessing(OutputPreProcessing):
 
     @classmethod
     def convert_to_dataframe(cls, data, **kwargs):
-        """"""
+        """Transform data (list of dicts) into a dataframe."""
         table = []
         for d in data:
             if not d['hierarchy']:

--- a/resources/data_dict.tmpl
+++ b/resources/data_dict.tmpl
@@ -34,7 +34,7 @@
 <body>
 
 <div class="panel-group">
-    {% for db, subdict in mongo_schema.items() %}
+    {% for db, subdict in data.items() %}
     <div class="panel level1">
         <div class="panel-heading">
             <h4>

--- a/resources/data_dict.tmpl
+++ b/resources/data_dict.tmpl
@@ -45,12 +45,16 @@
             <div class="panel-group" >
                 {% for coll, table in subdict.items() %}
                 <div class="panel panel-default">
+                    {% if coll != '' %}
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_{{ db }}_{{ coll }}">{{ coll }}</a>
                         </h4>
                     </div>
                     <div id="collapse_{{ db }}_{{ coll }}" class="panel-collapse collapse">
+                    {% else %}
+                    <div id="collapse_{{ db }}_{{ coll }}" class="panel-collapse">
+                    {% endif %}
                         <div class="panel-body">
                             <table>
                                 <tr>

--- a/tests/resources/expected/data_dict.html
+++ b/tests/resources/expected/data_dict.html
@@ -10,31 +10,31 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
     <style>
-        table {
-            font-family: arial, sans-serif;
-            border-collapse: collapse;
-            width: 100%;
-        }
+    table {
+        font-family: arial, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+    }
 
-        td, th {
-            border: 1px solid #dddddd;
-            text-align: left;
-            padding: 8px;
-        }
+    td, th {
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
 
-        tr:nth-child(even) {
-            background-color: #F0F8FF;
-        }
+    tr:nth-child(even) {
+        background-color: #F0F8FF;
+    }
 
-        .level1 {
-            background-color: lightblue !important;
-        }
+    .level1 {
+        background-color: lightblue !important;
+    }
     </style>
 </head>
 <body>
 
 <div class="panel-group">
-
+    
     <div class="panel level1">
         <div class="panel-heading">
             <h4>
@@ -43,579 +43,583 @@
         </div>
         <div id="collapse_test_db1" class="panel-collapse collapse">
             <div class="panel-group" >
-
+                
                 <div class="panel panel-default">
+                    
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col1">test_col1</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col1" class="panel-collapse collapse">
+                    
                         <div class="panel-body">
                             <table>
                                 <tr>
-
+                                    
                                     <th style="text-align: left">Field_compact_name</th>
-
+                                    
                                     <th style="text-align: left">Field_name</th>
-
+                                    
                                     <th style="text-align: left">Full_name</th>
-
+                                    
                                     <th style="text-align: left">Description</th>
-
+                                    
                                     <th style="text-align: left">Count</th>
-
+                                    
                                     <th style="text-align: left">Percentage</th>
-
+                                    
                                     <th style="text-align: left">Types_count</th>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>oid : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>OBJECT : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . building</td>
-
+                                    
                                     <td>building</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . coord</td>
-
+                                    
                                     <td>coord</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(float : 50714, null : 2) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . street</td>
-
+                                    
                                     <td>street</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . zipcode</td>
-
+                                    
                                     <td>zipcode</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(OBJECT : 93463, null : 738) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : date</td>
-
+                                    
                                     <td>date</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>date : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : grade</td>
-
+                                    
                                     <td>grade</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>string : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : score</td>
-
+                                    
                                     <td>score</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>integer : 93450, null : 13</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                             </table>
                         </div>
                     </div>
                 </div>
-
+                
                 <div class="panel panel-default">
+                    
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col2">test_col2</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col2" class="panel-collapse collapse">
+                    
                         <div class="panel-body">
                             <table>
                                 <tr>
-
+                                    
                                     <th style="text-align: left">Field_compact_name</th>
-
+                                    
                                     <th style="text-align: left">Field_name</th>
-
+                                    
                                     <th style="text-align: left">Full_name</th>
-
+                                    
                                     <th style="text-align: left">Description</th>
-
+                                    
                                     <th style="text-align: left">Count</th>
-
+                                    
                                     <th style="text-align: left">Percentage</th>
-
+                                    
                                     <th style="text-align: left">Types_count</th>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>oid : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>OBJECT : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . building</td>
-
+                                    
                                     <td>building</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . coord</td>
-
+                                    
                                     <td>coord</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(float : 50714, null : 2) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . street</td>
-
+                                    
                                     <td>street</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . zipcode</td>
-
+                                    
                                     <td>zipcode</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(OBJECT : 93463, null : 738) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : date</td>
-
+                                    
                                     <td>date</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>date : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : grade</td>
-
+                                    
                                     <td>grade</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>string : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : score</td>
-
+                                    
                                     <td>score</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>integer : 93450, null : 13</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                             </table>
                         </div>
                     </div>
                 </div>
-
+                
             </div>
         </div>
     </div>
-
+    
     <div class="panel level1">
         <div class="panel-heading">
             <h4>
@@ -624,295 +628,297 @@
         </div>
         <div id="collapse_test_db2" class="panel-collapse collapse">
             <div class="panel-group" >
-
+                
                 <div class="panel panel-default">
+                    
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db2_test_col">test_col</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db2_test_col" class="panel-collapse collapse">
+                    
                         <div class="panel-body">
                             <table>
                                 <tr>
-
+                                    
                                     <th style="text-align: left">Field_compact_name</th>
-
+                                    
                                     <th style="text-align: left">Field_name</th>
-
+                                    
                                     <th style="text-align: left">Full_name</th>
-
+                                    
                                     <th style="text-align: left">Description</th>
-
+                                    
                                     <th style="text-align: left">Count</th>
-
+                                    
                                     <th style="text-align: left">Percentage</th>
-
+                                    
                                     <th style="text-align: left">Types_count</th>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>oid : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>address</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>OBJECT : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . building</td>
-
+                                    
                                     <td>building</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . coord</td>
-
+                                    
                                     <td>coord</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(float : 50714, null : 2) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . street</td>
-
+                                    
                                     <td>street</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> . zipcode</td>
-
+                                    
                                     <td>zipcode</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>borough</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>cuisine</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>grades</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>ARRAY(OBJECT : 93463, null : 738) : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : date</td>
-
+                                    
                                     <td>date</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>date : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : grade</td>
-
+                                    
                                     <td>grade</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>string : 93463</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td> : score</td>
-
+                                    
                                     <td>score</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>93463</td>
-
+                                    
                                     <td>368.56</td>
-
+                                    
                                     <td>integer : 93450, null : 13</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>name</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                                 <tr>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>restaurant_id</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>None</td>
-
+                                    
                                     <td>25359</td>
-
+                                    
                                     <td>100.0</td>
-
+                                    
                                     <td>string : 25359</td>
-
+                                    
                                 </tr>
-
+                                
                             </table>
                         </div>
                     </div>
                 </div>
-
+                
             </div>
         </div>
     </div>
-
+    
 </div>
 
 </body>

--- a/tests/resources/expected/data_dict_default.html
+++ b/tests/resources/expected/data_dict_default.html
@@ -45,12 +45,14 @@
             <div class="panel-group" >
                 
                 <div class="panel panel-default">
+
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col1">test_col1</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col1" class="panel-collapse collapse">
+
                         <div class="panel-body">
                             <table>
                                 <tr>
@@ -329,12 +331,14 @@
                 </div>
 
                 <div class="panel panel-default">
+
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col2">test_col2</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col2" class="panel-collapse collapse">
+
                         <div class="panel-body">
                             <table>
                                 <tr>
@@ -626,12 +630,14 @@
             <div class="panel-group" >
 
                 <div class="panel panel-default">
+
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db2_test_col">test_col</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db2_test_col" class="panel-collapse collapse">
+
                         <div class="panel-body">
                             <table>
                                 <tr>

--- a/tests/resources/expected/data_dict_filtered.html
+++ b/tests/resources/expected/data_dict_filtered.html
@@ -45,12 +45,14 @@
             <div class="panel-group" >
                 
                 <div class="panel panel-default">
+
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col1">test_col1</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col1" class="panel-collapse collapse">
+
                         <div class="panel-body">
                             <table>
                                 <tr>
@@ -293,12 +295,14 @@
                 </div>
                 
                 <div class="panel panel-default">
+
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#collapse_test_db1_test_col2">test_col2</a>
                         </h4>
                     </div>
                     <div id="collapse_test_db1_test_col2" class="panel-collapse collapse">
+
                         <div class="panel-body">
                             <table>
                                 <tr>

--- a/tests/resources/expected/schema_diff.html
+++ b/tests/resources/expected/schema_diff.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>DataDict</title>
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
+    <style>
+    table {
+        font-family: arial, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+    }
+
+    td, th {
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
+
+    tr:nth-child(even) {
+        background-color: #F0F8FF;
+    }
+
+    .level1 {
+        background-color: lightblue !important;
+    }
+    </style>
+</head>
+<body>
+
+<div class="panel-group">
+    
+    <div class="panel level1">
+        <div class="panel-heading">
+            <h4>
+                <a data-toggle="collapse" href="#collapse_db0" style="color: #333333 !important;">db0</a>
+            </h4>
+        </div>
+        <div id="collapse_db0" class="panel-collapse collapse">
+            <div class="panel-group" >
+                
+                <div class="panel panel-default">
+                    
+                    <div id="collapse_db0_" class="panel-collapse">
+                    
+                        <div class="panel-body">
+                            <table>
+                                <tr>
+                                    
+                                    <th style="text-align: left">Hierarchy</th>
+                                    
+                                    <th style="text-align: left">In Schema</th>
+                                    
+                                    <th style="text-align: left">In Expected</th>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>db0</td>
+                                    
+                                    <td>None</td>
+                                    
+                                </tr>
+                                
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                
+            </div>
+        </div>
+    </div>
+    
+    <div class="panel level1">
+        <div class="panel-heading">
+            <h4>
+                <a data-toggle="collapse" href="#collapse_db1" style="color: #333333 !important;">db1</a>
+            </h4>
+        </div>
+        <div id="collapse_db1" class="panel-collapse collapse">
+            <div class="panel-group" >
+                
+                <div class="panel panel-default">
+                    
+                    <div id="collapse_db1_" class="panel-collapse">
+                    
+                        <div class="panel-body">
+                            <table>
+                                <tr>
+                                    
+                                    <th style="text-align: left">Hierarchy</th>
+                                    
+                                    <th style="text-align: left">In Schema</th>
+                                    
+                                    <th style="text-align: left">In Expected</th>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>None</td>
+                                    
+                                    <td>db1</td>
+                                    
+                                </tr>
+                                
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                
+            </div>
+        </div>
+    </div>
+    
+    <div class="panel level1">
+        <div class="panel-heading">
+            <h4>
+                <a data-toggle="collapse" href="#collapse_db" style="color: #333333 !important;">db</a>
+            </h4>
+        </div>
+        <div id="collapse_db" class="panel-collapse collapse">
+            <div class="panel-group" >
+                
+                <div class="panel panel-default">
+                    
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            <a data-toggle="collapse" href="#collapse_db_coll1">coll1</a>
+                        </h4>
+                    </div>
+                    <div id="collapse_db_coll1" class="panel-collapse collapse">
+                    
+                        <div class="panel-body">
+                            <table>
+                                <tr>
+                                    
+                                    <th style="text-align: left">Hierarchy</th>
+                                    
+                                    <th style="text-align: left">In Schema</th>
+                                    
+                                    <th style="text-align: left">In Expected</th>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>coll1</td>
+                                    
+                                    <td>None</td>
+                                    
+                                </tr>
+                                
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="panel panel-default">
+                    
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            <a data-toggle="collapse" href="#collapse_db_coll2">coll2</a>
+                        </h4>
+                    </div>
+                    <div id="collapse_db_coll2" class="panel-collapse collapse">
+                    
+                        <div class="panel-body">
+                            <table>
+                                <tr>
+                                    
+                                    <th style="text-align: left">Hierarchy</th>
+                                    
+                                    <th style="text-align: left">In Schema</th>
+                                    
+                                    <th style="text-align: left">In Expected</th>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>None</td>
+                                    
+                                    <td>coll2</td>
+                                    
+                                </tr>
+                                
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="panel panel-default">
+                    
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            <a data-toggle="collapse" href="#collapse_db_coll">coll</a>
+                        </h4>
+                    </div>
+                    <div id="collapse_db_coll" class="panel-collapse collapse">
+                    
+                        <div class="panel-body">
+                            <table>
+                                <tr>
+                                    
+                                    <th style="text-align: left">Hierarchy</th>
+                                    
+                                    <th style="text-align: left">In Schema</th>
+                                    
+                                    <th style="text-align: left">In Expected</th>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>field2</td>
+                                    
+                                    <td>None</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td></td>
+                                    
+                                    <td>None</td>
+                                    
+                                    <td>field4</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td>field3</td>
+                                    
+                                    <td>{'type': 'boolean'}</td>
+                                    
+                                    <td>{'type': 'string'}</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td>field.array_subfield</td>
+                                    
+                                    <td>None</td>
+                                    
+                                    <td>subsubfield2</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td>field.array_subfield.subsubfield</td>
+                                    
+                                    <td>{'type': 'integer'}</td>
+                                    
+                                    <td>{'type': 'boolean'}</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td>field5</td>
+                                    
+                                    <td>{'array_type': 'string'}</td>
+                                    
+                                    <td>{'array_type': 'integer'}</td>
+                                    
+                                </tr>
+                                
+                                <tr>
+                                    
+                                    <td>field6</td>
+                                    
+                                    <td>{'type': 'ARRAY'}</td>
+                                    
+                                    <td>{'type': 'string'}</td>
+                                    
+                                </tr>
+                                
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                
+            </div>
+        </div>
+    </div>
+    
+</div>
+
+</body>
+</html>

--- a/tests/resources/expected/schema_diff.html
+++ b/tests/resources/expected/schema_diff.html
@@ -54,9 +54,9 @@
                                     
                                     <th style="text-align: left">Hierarchy</th>
                                     
-                                    <th style="text-align: left">In Schema</th>
+                                    <th style="text-align: left">Previous Schema</th>
                                     
-                                    <th style="text-align: left">In Expected</th>
+                                    <th style="text-align: left">New Schema</th>
                                     
                                 </tr>
                                 
@@ -98,9 +98,9 @@
                                     
                                     <th style="text-align: left">Hierarchy</th>
                                     
-                                    <th style="text-align: left">In Schema</th>
+                                    <th style="text-align: left">Previous Schema</th>
                                     
-                                    <th style="text-align: left">In Expected</th>
+                                    <th style="text-align: left">New Schema</th>
                                     
                                 </tr>
                                 
@@ -147,9 +147,9 @@
                                     
                                     <th style="text-align: left">Hierarchy</th>
                                     
-                                    <th style="text-align: left">In Schema</th>
+                                    <th style="text-align: left">Previous Schema</th>
                                     
-                                    <th style="text-align: left">In Expected</th>
+                                    <th style="text-align: left">New Schema</th>
                                     
                                 </tr>
                                 
@@ -183,9 +183,9 @@
                                     
                                     <th style="text-align: left">Hierarchy</th>
                                     
-                                    <th style="text-align: left">In Schema</th>
+                                    <th style="text-align: left">Previous Schema</th>
                                     
-                                    <th style="text-align: left">In Expected</th>
+                                    <th style="text-align: left">New Schema</th>
                                     
                                 </tr>
                                 
@@ -219,9 +219,9 @@
                                     
                                     <th style="text-align: left">Hierarchy</th>
                                     
-                                    <th style="text-align: left">In Schema</th>
+                                    <th style="text-align: left">Previous Schema</th>
                                     
-                                    <th style="text-align: left">In Expected</th>
+                                    <th style="text-align: left">New Schema</th>
                                     
                                 </tr>
                                 

--- a/tests/resources/expected/schema_diff.md
+++ b/tests/resources/expected/schema_diff.md
@@ -1,0 +1,35 @@
+
+### Database: db0
+|Hierarchy                            |In Schema                    |In Expected                   |
+|-------------------------------------|-----------------------------|------------------------------|
+|                                     |db0                          |None                          |
+
+
+### Database: db1
+|Hierarchy                            |In Schema                    |In Expected                   |
+|-------------------------------------|-----------------------------|------------------------------|
+|                                     |None                         |db1                           |
+
+
+### Database: db
+#### Collection: coll1 
+|Hierarchy                            |In Schema                    |In Expected                   |
+|-------------------------------------|-----------------------------|------------------------------|
+|                                     |coll1                        |None                          |
+
+#### Collection: coll2 
+|Hierarchy                            |In Schema                    |In Expected                   |
+|-------------------------------------|-----------------------------|------------------------------|
+|                                     |None                         |coll2                         |
+
+#### Collection: coll 
+|Hierarchy                            |In Schema                    |In Expected                   |
+|-------------------------------------|-----------------------------|------------------------------|
+|                                     |field2                       |None                          |
+|                                     |None                         |field4                        |
+|field3                               |{'type': 'boolean'}          |{'type': 'string'}            |
+|field.array_subfield                 |None                         |subsubfield2                  |
+|field.array_subfield.subsubfield     |{'type': 'integer'}          |{'type': 'boolean'}           |
+|field5                               |{'array_type': 'string'}     |{'array_type': 'integer'}     |
+|field6                               |{'type': 'ARRAY'}            |{'type': 'string'}            |
+

--- a/tests/resources/expected/schema_diff.md
+++ b/tests/resources/expected/schema_diff.md
@@ -1,29 +1,29 @@
 
 ### Database: db0
-|Hierarchy                            |In Schema                    |In Expected                   |
+|Hierarchy                            |Previous Schema              |New Schema                    |
 |-------------------------------------|-----------------------------|------------------------------|
 |                                     |db0                          |None                          |
 
 
 ### Database: db1
-|Hierarchy                            |In Schema                    |In Expected                   |
+|Hierarchy                            |Previous Schema              |New Schema                    |
 |-------------------------------------|-----------------------------|------------------------------|
 |                                     |None                         |db1                           |
 
 
 ### Database: db
 #### Collection: coll1 
-|Hierarchy                            |In Schema                    |In Expected                   |
+|Hierarchy                            |Previous Schema              |New Schema                    |
 |-------------------------------------|-----------------------------|------------------------------|
 |                                     |coll1                        |None                          |
 
 #### Collection: coll2 
-|Hierarchy                            |In Schema                    |In Expected                   |
+|Hierarchy                            |Previous Schema              |New Schema                    |
 |-------------------------------------|-----------------------------|------------------------------|
 |                                     |None                         |coll2                         |
 
 #### Collection: coll 
-|Hierarchy                            |In Schema                    |In Expected                   |
+|Hierarchy                            |Previous Schema              |New Schema                    |
 |-------------------------------------|-----------------------------|------------------------------|
 |                                     |field2                       |None                          |
 |                                     |None                         |field4                        |

--- a/tests/resources/expected/schema_diff.txt
+++ b/tests/resources/expected/schema_diff.txt
@@ -1,0 +1,30 @@
+
+### Database: db0
+Hierarchy                            Previous Schema              New Schema
+                                     db0                          None
+
+
+### Database: db1
+Hierarchy                            Previous Schema New Schema                   
+                                     None            db1
+
+
+### Database: db
+--- Collection: coll1 
+Hierarchy                            Previous Schema              New Schema
+                                     coll1                        None
+
+--- Collection: coll2 
+Hierarchy                            Previous Schema New Schema                   
+                                     None            coll2
+
+--- Collection: coll 
+Hierarchy                            Previous Schema              New Schema                   
+                                     field2                                               None
+                                                            None  field4                      
+field3                               {'type': 'boolean'}          {'type': 'string'}          
+field.array_subfield                                        None  subsubfield2                
+field.array_subfield.subsubfield     {'type': 'integer'}          {'type': 'boolean'}         
+field5                               {'array_type': 'string'}     {'array_type': 'integer'}   
+field6                               {'type': 'ARRAY'}            {'type': 'string'}
+

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -14,22 +14,22 @@ def df_columns():
 
 @pytest.fixture(scope='module')
 def long_diff():
-    return [{'hierarchy': '', 'schema': 'db0', 'expected': None},
-            {'hierarchy': '', 'schema': None, 'expected': 'db1'},
-            {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
-            {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
-            {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
-            {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
-            {'hierarchy': 'db.coll.field3', 'schema': {'type': 'boolean'},
-             'expected': {'type': 'string'}},
+    return [{'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None},
+            {'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
+            {'hierarchy': 'db', 'prev_schema': 'coll1', 'new_schema': None},
+            {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
+            {'hierarchy': 'db.coll', 'prev_schema': 'field2', 'new_schema': None},
+            {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
+            {'hierarchy': 'db.coll.field3', 'prev_schema': {'type': 'boolean'},
+             'new_schema': {'type': 'string'}},
             {'hierarchy': 'db.coll.field.array_subfield',
-             'schema': None, 'expected': 'subsubfield2'},
+             'prev_schema': None, 'new_schema': 'subsubfield2'},
             {'hierarchy': 'db.coll.field.array_subfield.subsubfield',
-             'schema': {'type': 'integer'}, 'expected': {'type': 'boolean'}},
-            {'hierarchy': 'db.coll.field5', 'schema': {'array_type': 'string'},
-             'expected': {'array_type': 'integer'}},
-            {'hierarchy': 'db.coll.field6', 'schema': {'type': 'ARRAY'},
-             'expected': {'type': 'string'}}]
+             'prev_schema': {'type': 'integer'}, 'new_schema': {'type': 'boolean'}},
+            {'hierarchy': 'db.coll.field5', 'prev_schema': {'array_type': 'string'},
+             'new_schema': {'array_type': 'integer'}},
+            {'hierarchy': 'db.coll.field6', 'prev_schema': {'type': 'ARRAY'},
+             'new_schema': {'type': 'string'}}]
 
 
 def test00_compare_schemas_bases_very_simple():
@@ -38,22 +38,22 @@ def test00_compare_schemas_bases_very_simple():
 
 
 def test01_compare_schemas_bases_diff_keys():
-    schema = {'db': {'coll': {'object': {
+    prev_schema = {'db': {'coll': {'object': {
         'field1': {'type': 'string', 'description': 'a_description'}}}}}
-    exp_schema = {'db': {'coll': {'object': {
+    new_schema = {'db': {'coll': {'object': {
         'field1': {'type': 'string', 'types_count': {'string': 1}}}}}}
-    assert compare_schemas_bases(schema, exp_schema) == []
+    assert compare_schemas_bases(prev_schema, new_schema) == []
 
 
 def test02_compare_schemas_bases_simple_diff():
-    schema = {'db': {'coll': {'object': {'field1': {'type': 'string'},
-                                         'field2': {'type': 'integer'},
-                                         'field3': {'type': 'boolean'},
-                                         'field5': {'type': 'ARRAY', 'array_type': 'string'},
-                                         'field6': {'type': 'ARRAY', 'array_type': 'string'}}},
-                     'coll1': {}},
-              'db0': {}}
-    exp_schema = {'db': {'coll': {'object': {'field1': {'type': 'string', 'count': 1},
+    prev_schema = {'db': {'coll': {'object': {'field1': {'type': 'string'},
+                                              'field2': {'type': 'integer'},
+                                              'field3': {'type': 'boolean'},
+                                              'field5': {'type': 'ARRAY', 'array_type': 'string'},
+                                              'field6': {'type': 'ARRAY', 'array_type': 'string'}}},
+                          'coll1': {}},
+                   'db0': {}}
+    new_schema = {'db': {'coll': {'object': {'field1': {'type': 'string', 'count': 1},
                                              'field3': {'type': 'string'},
                                              'field4': {'type': 'boolean'},
                                              'field5': {'type': 'ARRAY', 'array_type': 'integer'},
@@ -61,50 +61,50 @@ def test02_compare_schemas_bases_simple_diff():
                                              }},
                          'coll2': {}},
                   'db1': {}}
-    exp_diff = [{'hierarchy': '', 'schema': 'db0', 'expected': None},
-                {'hierarchy': '', 'schema': None, 'expected': 'db1'},
-                {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
-                {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
-                {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
-                {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
-                {'hierarchy': 'db.coll.field3', 'schema': {'type': 'boolean'},
-                 'expected': {'type': 'string'}},
-                {'hierarchy': 'db.coll.field5', 'schema': {'array_type': 'string'},
-                 'expected': {'array_type': 'integer'}},
-                {'hierarchy': 'db.coll.field6', 'schema': {'type': 'ARRAY'},
-                 'expected': {'type': 'string'}}]
-    res = compare_schemas_bases(schema, exp_schema)
+    exp_diff = [{'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None},
+                {'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
+                {'hierarchy': 'db', 'prev_schema': 'coll1', 'new_schema': None},
+                {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
+                {'hierarchy': 'db.coll', 'prev_schema': 'field2', 'new_schema': None},
+                {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
+                {'hierarchy': 'db.coll.field3', 'prev_schema': {'type': 'boolean'},
+                 'new_schema': {'type': 'string'}},
+                {'hierarchy': 'db.coll.field5', 'prev_schema': {'array_type': 'string'},
+                 'new_schema': {'array_type': 'integer'}},
+                {'hierarchy': 'db.coll.field6', 'prev_schema': {'type': 'ARRAY'},
+                 'new_schema': {'type': 'string'}}]
+    res = compare_schemas_bases(prev_schema, new_schema)
     assert res == exp_diff
 
 
 def test03_compare_schema_nested():
-    schema = {'db': {'coll': {'object': {
+    prev_schema = {'db': {'coll': {'object': {
         'field': {'type': 'ARRAY', 'array_type': 'OBJECT', 'object': {
             'array_subfield': {'type': 'OBJECT', 'object': {
                 'subsubfield': {'type': 'integer'}
             }}}}}}}}
-    exp_schema = {'db': {'coll': {'object': {
+    new_schema = {'db': {'coll': {'object': {
         'field': {'type': 'ARRAY', 'array_type': 'OBJECT', 'object': {
             'array_subfield': {'type': 'OBJECT', 'object': {
                 'subsubfield': {'type': 'boolean'},
                 'subsubfield2': {'type': 'boolean'}
             }}}}}}}}
     exp_diff = [{'hierarchy': 'db.coll.field.array_subfield',
-                 'schema': None, 'expected': 'subsubfield2'},
+                 'prev_schema': None, 'new_schema': 'subsubfield2'},
                 {'hierarchy': 'db.coll.field.array_subfield.subsubfield',
-                 'schema': {'type': 'integer'}, 'expected': {'type': 'boolean'}}]
-    res = compare_schemas_bases(schema, exp_schema)
+                 'prev_schema': {'type': 'integer'}, 'new_schema': {'type': 'boolean'}}]
+    res = compare_schemas_bases(prev_schema, new_schema)
     assert res == exp_diff
 
 
 def test04_is_retrocompatible_true():
-    diff = [{'hierarchy': '', 'schema': 'db0', 'expected': None},
-            {'hierarchy': '', 'schema': None, 'expected': 'db1'},
-            {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
-            {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
-            {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
-            {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
-            {'hierarchy': 'db.coll.field', 'schema': None, 'expected': 'subfield'}]
+    diff = [{'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None},
+            {'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
+            {'hierarchy': 'db', 'prev_schema': 'coll1', 'new_schema': None},
+            {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
+            {'hierarchy': 'db.coll', 'prev_schema': 'field2', 'new_schema': None},
+            {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
+            {'hierarchy': 'db.coll.field', 'prev_schema': None, 'new_schema': 'subfield'}]
     assert is_retrocompatible(diff)
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -98,14 +98,29 @@ def test03_compare_schema_nested():
 
 
 def test04_is_retrocompatible_true():
-    diff = [{'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None},
-            {'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
-            {'hierarchy': 'db', 'prev_schema': 'coll1', 'new_schema': None},
+    diff = [{'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
             {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
-            {'hierarchy': 'db.coll', 'prev_schema': 'field2', 'new_schema': None},
             {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
             {'hierarchy': 'db.coll.field', 'prev_schema': None, 'new_schema': 'subfield'}]
     assert is_retrocompatible(diff)
+
+
+def test05_is_retrocompatible_false_deleted_field():
+    diff = [{'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
+            {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
+            {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
+            {'hierarchy': 'db.coll.field', 'prev_schema': None, 'new_schema': 'subfield'},
+            {'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None}]
+    assert not is_retrocompatible(diff)
+
+
+def test06_is_retrocompatible_false_type_modif():
+    diff = [{'hierarchy': '', 'prev_schema': None, 'new_schema': 'db1'},
+            {'hierarchy': 'db', 'prev_schema': None, 'new_schema': 'coll2'},
+            {'hierarchy': 'db.coll', 'prev_schema': None, 'new_schema': 'field4'},
+            {'hierarchy': 'db.coll.field', 'prev_schema': None, 'new_schema': 'subfield'},
+            {'hierarchy': '', 'prev_schema': {'type': 'integer'}, 'new_schema': {'type': 'string'}}]
+    assert not is_retrocompatible(diff)
 
 
 def test05_is_retrocompatible_false(long_diff):

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -95,3 +95,18 @@ def test03_compare_schema_nested():
                  'schema': {'type': 'integer'}, 'expected': {'type': 'boolean'}}]
     res = compare_schemas_bases(schema, exp_schema)
     assert res == exp_diff
+
+
+def test04_is_retrocompatible_true():
+    diff = [{'hierarchy': '', 'schema': 'db0', 'expected': None},
+            {'hierarchy': '', 'schema': None, 'expected': 'db1'},
+            {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
+            {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
+            {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
+            {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
+            {'hierarchy': 'db.coll.field', 'schema': None, 'expected': 'subfield'}]
+    assert is_retrocompatible(diff)
+
+
+def test05_is_retrocompatible_false(long_diff):
+    assert not is_retrocompatible(long_diff)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,97 @@
+import os
+
+import pytest
+
+from pymongo_schema.compare import *
+
+TEST_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture(scope='module')
+def df_columns():
+    return ['Database', 'Collection', 'Hierarchy', 'In Schema', 'In Expected']
+
+
+@pytest.fixture(scope='module')
+def long_diff():
+    return [{'hierarchy': '', 'schema': 'db0', 'expected': None},
+            {'hierarchy': '', 'schema': None, 'expected': 'db1'},
+            {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
+            {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
+            {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
+            {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
+            {'hierarchy': 'db.coll.field3', 'schema': {'type': 'boolean'},
+             'expected': {'type': 'string'}},
+            {'hierarchy': 'db.coll.field.array_subfield',
+             'schema': None, 'expected': 'subsubfield2'},
+            {'hierarchy': 'db.coll.field.array_subfield.subsubfield',
+             'schema': {'type': 'integer'}, 'expected': {'type': 'boolean'}},
+            {'hierarchy': 'db.coll.field5', 'schema': {'array_type': 'string'},
+             'expected': {'array_type': 'integer'}},
+            {'hierarchy': 'db.coll.field6', 'schema': {'type': 'ARRAY'},
+             'expected': {'type': 'string'}}]
+
+
+def test00_compare_schemas_bases_very_simple():
+    schema = {'db': {'coll': {'object': {'field1': {'type': 'string'}}}}}
+    assert compare_schemas_bases(schema, schema) == []
+
+
+def test01_compare_schemas_bases_diff_keys():
+    schema = {'db': {'coll': {'object': {
+        'field1': {'type': 'string', 'description': 'a_description'}}}}}
+    exp_schema = {'db': {'coll': {'object': {
+        'field1': {'type': 'string', 'types_count': {'string': 1}}}}}}
+    assert compare_schemas_bases(schema, exp_schema) == []
+
+
+def test02_compare_schemas_bases_simple_diff():
+    schema = {'db': {'coll': {'object': {'field1': {'type': 'string'},
+                                         'field2': {'type': 'integer'},
+                                         'field3': {'type': 'boolean'},
+                                         'field5': {'type': 'ARRAY', 'array_type': 'string'},
+                                         'field6': {'type': 'ARRAY', 'array_type': 'string'}}},
+                     'coll1': {}},
+              'db0': {}}
+    exp_schema = {'db': {'coll': {'object': {'field1': {'type': 'string', 'count': 1},
+                                             'field3': {'type': 'string'},
+                                             'field4': {'type': 'boolean'},
+                                             'field5': {'type': 'ARRAY', 'array_type': 'integer'},
+                                             'field6': {'type': 'string'}
+                                             }},
+                         'coll2': {}},
+                  'db1': {}}
+    exp_diff = [{'hierarchy': '', 'schema': 'db0', 'expected': None},
+                {'hierarchy': '', 'schema': None, 'expected': 'db1'},
+                {'hierarchy': 'db', 'schema': 'coll1', 'expected': None},
+                {'hierarchy': 'db', 'schema': None, 'expected': 'coll2'},
+                {'hierarchy': 'db.coll', 'schema': 'field2', 'expected': None},
+                {'hierarchy': 'db.coll', 'schema': None, 'expected': 'field4'},
+                {'hierarchy': 'db.coll.field3', 'schema': {'type': 'boolean'},
+                 'expected': {'type': 'string'}},
+                {'hierarchy': 'db.coll.field5', 'schema': {'array_type': 'string'},
+                 'expected': {'array_type': 'integer'}},
+                {'hierarchy': 'db.coll.field6', 'schema': {'type': 'ARRAY'},
+                 'expected': {'type': 'string'}}]
+    res = compare_schemas_bases(schema, exp_schema)
+    assert res == exp_diff
+
+
+def test03_compare_schema_nested():
+    schema = {'db': {'coll': {'object': {
+        'field': {'type': 'ARRAY', 'array_type': 'OBJECT', 'object': {
+            'array_subfield': {'type': 'OBJECT', 'object': {
+                'subsubfield': {'type': 'integer'}
+            }}}}}}}}
+    exp_schema = {'db': {'coll': {'object': {
+        'field': {'type': 'ARRAY', 'array_type': 'OBJECT', 'object': {
+            'array_subfield': {'type': 'OBJECT', 'object': {
+                'subsubfield': {'type': 'boolean'},
+                'subsubfield2': {'type': 'boolean'}
+            }}}}}}}}
+    exp_diff = [{'hierarchy': 'db.coll.field.array_subfield',
+                 'schema': None, 'expected': 'subsubfield2'},
+                {'hierarchy': 'db.coll.field.array_subfield.subsubfield',
+                 'schema': {'type': 'integer'}, 'expected': {'type': 'boolean'}}]
+    res = compare_schemas_bases(schema, exp_schema)
+    assert res == exp_diff

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -72,7 +72,7 @@ def columns():
 
 @pytest.fixture(scope='module')
 def diff_columns():
-    return ['Database', 'Collection', 'Hierarchy', 'In Schema', 'In Expected']
+    return ['Database', 'Collection', 'Hierarchy', 'Previous Schema', 'New Schema']
 
 
 @pytest.fixture(scope='module')
@@ -335,7 +335,7 @@ def test12_write_output_dict_schema_non_ascii(columns):
 
 def test13_schema_diff_to_df_simple(diff_columns):
     res = _DiffPreProcessing.convert_to_dataframe(
-        [{'hierarchy': '', 'schema': 'db0', 'expected': None}])
+        [{'hierarchy': '', 'prev_schema': 'db0', 'new_schema': None}])
     exp = pd.DataFrame([['db0', '', '', 'db0', None]],
                        columns=diff_columns)
     assert_frame_equal(res, exp)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -376,3 +376,12 @@ def test16_schema_diff_to_md(long_diff):
     write_output_dict(long_diff, arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
+
+
+def test17_schema_diff_to_txt(long_diff):
+    output_file = os.path.join(TEST_DIR, 'output_test_diff.txt')
+    expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'schema_diff.txt')
+    arg = {'--format': ['txt'], '--output': output_file, '--category': 'diff'}
+    write_output_dict(long_diff, arg)
+    assert filecmp.cmp(output_file, expected_file)
+    os.remove(output_file)


### PR DESCRIPTION
This PR contains several steps that have been needed to add the compare module:
- export: introduce the notion of 'category' of output (schema, mapping, diff, ...)
- export: introduce PreProcessing classes for each category (only schema and diff for now)
- add compare module and include it in the CLI

The compare module allows to:
- generate a simple report with differences between two schemas
- decide whether those differences are compatible