### PR TITLE
docopt -> argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Usage:
     python -m pymongo_schema extract -h
     usage:  [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--port PORT] [--host HOST]
                  [-d [DATABASES [DATABASES ...]]] [-c [COLLECTIONS [COLLECTIONS ...]]]
+                 [--columns COLUMNS [COLUMNS ...]] [--without-counts]
                  
     python -m pymongo_schema transform -h
     usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--category CATEGORY] [-n FILTER]
@@ -50,9 +51,11 @@ Usage:
                 
     python -m pymongo_schema transform -h
     usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [input]
+                [--columns COLUMNS [COLUMNS ...]] [--without-counts]
     
     python -m pymongo_schema compare -h
     usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [input]
+                [--columns COLUMNS [COLUMNS ...]] [--without-counts]
                          
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,21 +23,43 @@ pip install --upgrade git+https://github.com/pajachiet/pymongo-schema.git
 # Usage
 
 ```shell
-Usage:
-    pymongo_schema  -h | --help
-    pymongo_schema  extract [--database=DB --collection=COLLECTION... --port=PORT --host=HOST --output=FILENAME --format=FORMAT... --quiet]
-    pymongo_schema  transform [--input=FILENAME --filter=FILENAME --output=FILENAME --format=FORMAT... --columns=COLUMNS  --without-counts --quiet]
-    pymongo_schema  tosql [--input=FILENAME --output=FILENAME --quiet]
+python -m pymongo_schema -h
+usage: [-h] [--quiet] {extract,transform,tosql,compare} ...
 
-Commands:
-    extract                     Extract schema from a MongoDB instance
-    transform                   Transform a json schema to another format, eventually filtering or changing columns outputs
-    tosql                       Create a mapping from mongo schema to relational schema (json input and output)
+commands:
+  {extract,transform,tosql,compare}
+    extract             Extract schema from a MongoDB instance
+    transform           Transform a json schema to another format, potentially
+                        filtering or changing columns outputs
+    tosql               Create a mapping from mongo schema to relational
+                        schema (json input and output)
+    compare             Compare two schemas
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --quiet               Remove logging on standard output
+
+Usage:
+    python -m pymongo_schema extract -h
+    usage:  [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--port PORT] [--host HOST]
+                 [-d [DATABASES [DATABASES ...]]] [-c [COLLECTIONS [COLLECTIONS ...]]]
+                 
+    python -m pymongo_schema transform -h
+    usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--category CATEGORY] [-n FILTER]
+                [--columns COLUMNS [COLUMNS ...]] [--without-counts] [input]
+                
+    python -m pymongo_schema transform -h
+    usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [input]
+    
+    python -m pymongo_schema compare -h
+    usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [input]
+                         
+
 ```
 
 To display full usage, with options description, run:
 ```shell 
-pymongo-schema -h
+pymongo-schema <command> -h
 ```
 
 # Examples

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -16,7 +16,7 @@ from time import time
 import pymongo
 
 from pymongo_schema.compare import compare_schemas_bases
-from pymongo_schema.export import write_output_dict, HtmlOutput, TsvOutput
+from pymongo_schema.export import transform_data_to_file, HtmlOutput, TsvOutput
 from pymongo_schema.extract import extract_pymongo_client_schema
 from pymongo_schema.filter import filter_mongo_schema_namespaces
 from pymongo_schema.tosql import mongo_schema_to_mapping
@@ -92,8 +92,8 @@ def main(argv=None):
             Useful for usage from another python program.
     """
     parent_parser = ArgumentParser(add_help=False)
-    parent_parser.add_argument('-f', '--format', nargs='*', default=['json'],
-                               help="Output format for schema :  "
+    parent_parser.add_argument('-f', '--formats', nargs='*', default=['json'],
+                               help="List Output formats:  "
                                     "'tsv', 'xlsx', 'yaml', 'html', 'md' or 'json'"
                                     "Multiple format may be specified. [default: json]")
     parent_parser.add_argument('-o', '--output',
@@ -135,18 +135,18 @@ def main(argv=None):
     # Output dict
     logger.info('=== Write output')
     if output_dict:
-        write_output_dict(output_dict, vars(args))
+        transform_data_to_file(output_dict, **vars(args))
     else:
         logger.warn("WARNING : output is empty, we do not write any file.")
 
 
 def preprocess_arg(arg):
     """ Preprocess arguments from command line."""
-    if arg.output is None and 'xlsx' in arg.format:
+    if arg.output is None and 'xlsx' in arg.formats:
         logger.warn("WARNING : xlsx format is not supported on standard output. "
                     "Switching to tsv output.")
-        arg.format.remove('xlsx')
-        arg.format.append('tsv')
+        arg.formats.remove('xlsx')
+        arg.formats.append('tsv')
 
 
 def initialize_logger(arg):

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -25,6 +25,7 @@ logger = logging.getLogger()
 
 
 def add_subparser_extract(subparsers, parent_parsers):
+    """CLI argument parser for extract module"""
     subparser = subparsers.add_parser('extract', parents=parent_parsers)
     subparser.add_argument('-d', '--databases', nargs='*',
                            help='Only analyze those databases. By default analyze all databases '
@@ -39,6 +40,7 @@ def add_subparser_extract(subparsers, parent_parsers):
 
 
 def add_subparser_transform(subparsers, parent_parsers):
+    """CLI argument parser for transform module"""
     subparser = subparsers.add_parser('transform', parents=parent_parsers)
     subparser.add_argument('input', nargs='?',
                            help='json formatted input file (schema, mapping, ...). '
@@ -71,6 +73,7 @@ def add_subparser_transform(subparsers, parent_parsers):
 
 
 def add_subparser_tosql(subparsers, parent_parsers):
+    """CLI argument parser for tosql module"""
     subparser = subparsers.add_parser('tosql', parents=parent_parsers)
     subparser.add_argument('input', nargs='?',
                            help='Input schema file to map to sql (json format). '
@@ -78,6 +81,7 @@ def add_subparser_tosql(subparsers, parent_parsers):
 
 
 def add_subparser_compare(subparsers, parent_parsers):
+    """CLI argument parser for compare module"""
     subparser = subparsers.add_parser('compare', parents=parent_parsers)
     subparser.add_argument('input',
                            help='Input schema')
@@ -88,7 +92,7 @@ def add_subparser_compare(subparsers, parent_parsers):
 def main(argv=None):
     """ Launch pymongo_schema (assuming CLI).
 
-    :param argv: command line arguments to pass directly to docopt.
+    :param argv: command line arguments to pass directly to argparse.
             Useful for usage from another python program.
     """
     parent_parser = ArgumentParser(add_help=False)

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -16,7 +16,7 @@ from time import time
 import pymongo
 
 from pymongo_schema.compare import compare_schemas_bases
-from pymongo_schema.export import write_output_dict, HtmlOutput, _SchemaPreProcessing
+from pymongo_schema.export import write_output_dict, HtmlOutput, TsvOutput
 from pymongo_schema.extract import extract_pymongo_client_schema
 from pymongo_schema.filter import filter_mongo_schema_namespaces
 from pymongo_schema.tosql import mongo_schema_to_mapping
@@ -64,8 +64,8 @@ def add_subparser_transform(subparsers, parent_parsers):
                            Columns have to be separated by whitespace, and are case insensitive.
                            Default for 'html' and 'md' output is {}
                            Default for 'tsv' and 'xlsx' output is {}'''.format(
-                               HtmlOutput.default_columns['schema'],
-                               _SchemaPreProcessing.default_columns))
+                               HtmlOutput.get_default_columns()['schema'],
+                               TsvOutput.get_default_columns()['schema']))
     subparser.add_argument('--without-counts', action='store_true',
                            help='Remove counts information from json and yaml outputs')
 

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -53,26 +53,6 @@ def add_subparser_transform(subparsers, parent_parsers):
     subparser.add_argument('-n', '--filter',
                            help='Config file to read namespace to filter for schema input. '
                                 'json format expected.')
-    subparser.add_argument('--columns', nargs='+',
-                           help='''
-                           Columns to get in 'tsv', 'html', 'md' or 'xlsx' format.
-                           For schema, columns are to be chosen in :
-                               FIELD_FULL_NAME ('.' for subfields, ':' for subfields in arrays)
-                               FIELD_COMPACT_NAME (idem, without parent object names)
-                               FIELD_NAME
-                               DEPTH
-                               TYPE
-                               COUNT
-                               PROP_IN_OBJECT
-                               PERCENTAGE
-                               TYPES_COUNT
-                           Columns have to be separated by whitespace, and are case insensitive.
-                           Default for 'html' and 'md' output is {}
-                           Default for 'tsv' and 'xlsx' output is {}'''.format(
-                               HtmlOutput.get_default_columns()['schema'],
-                               TsvOutput.get_default_columns()['schema']))
-    subparser.add_argument('--without-counts', action='store_true',
-                           help='Remove counts information from json and yaml outputs')
 
 
 def add_subparser_tosql(subparsers, parent_parsers):
@@ -106,6 +86,26 @@ def main(argv=None):
                                help="List Output formats:  "
                                     "'tsv', 'xlsx', 'yaml', 'html', 'md' or 'json'"
                                     "Multiple format may be specified. [default: json]")
+    parent_parser.add_argument('--columns', nargs='+',
+                               help='''
+                               Columns to get in 'tsv', 'html', 'md' or 'xlsx' format.
+                               For schema, columns are to be chosen in :
+                                   FIELD_FULL_NAME ('.' for subfields, ':' for subfields in arrays)
+                                   FIELD_COMPACT_NAME (idem, without parent object names)
+                                   FIELD_NAME
+                                   DEPTH
+                                   TYPE
+                                   COUNT
+                                   PROP_IN_OBJECT
+                                   PERCENTAGE
+                                   TYPES_COUNT
+                               Columns have to be separated by whitespace, and are case insensitive.
+                               Default for 'html' and 'md' output is {}
+                               Default for 'tsv' and 'xlsx' output is {}'''.format(
+                                   HtmlOutput.get_default_columns()['schema'],
+                                   TsvOutput.get_default_columns()['schema']))
+    parent_parser.add_argument('--without-counts', action='store_true',
+                               help='Remove counts information from json and yaml outputs')
     parent_parser.add_argument('-o', '--output',
                                help='Output file. Default to standard output. Extension added '
                                     'automatically if omitted (useful for multi-format outputs)')

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -26,7 +26,8 @@ logger = logging.getLogger()
 
 def add_subparser_extract(subparsers, parent_parsers):
     """CLI argument parser for extract module"""
-    subparser = subparsers.add_parser('extract', parents=parent_parsers)
+    subparser = subparsers.add_parser('extract', parents=parent_parsers,
+                                      help='Extract schema from a MongoDB instance')
     subparser.add_argument('-d', '--databases', nargs='*',
                            help='Only analyze those databases. By default analyze all databases '
                                 'in MongoDB instance')
@@ -41,7 +42,9 @@ def add_subparser_extract(subparsers, parent_parsers):
 
 def add_subparser_transform(subparsers, parent_parsers):
     """CLI argument parser for transform module"""
-    subparser = subparsers.add_parser('transform', parents=parent_parsers)
+    subparser = subparsers.add_parser('transform', parents=parent_parsers,
+                                      help='Transform a json schema to another format, potentially '
+                                           'filtering or changing columns outputs')
     subparser.add_argument('input', nargs='?',
                            help='json formatted input file (schema, mapping, ...). '
                                 '[default standard input]')
@@ -74,7 +77,9 @@ def add_subparser_transform(subparsers, parent_parsers):
 
 def add_subparser_tosql(subparsers, parent_parsers):
     """CLI argument parser for tosql module"""
-    subparser = subparsers.add_parser('tosql', parents=parent_parsers)
+    subparser = subparsers.add_parser('tosql', parents=parent_parsers,
+                                      help='Create a mapping from mongo schema to relational '
+                                           'schema (json input and output)')
     subparser.add_argument('input', nargs='?',
                            help='Input schema file to map to sql (json format). '
                                 'Default to standard input')
@@ -82,10 +87,11 @@ def add_subparser_tosql(subparsers, parent_parsers):
 
 def add_subparser_compare(subparsers, parent_parsers):
     """CLI argument parser for compare module"""
-    subparser = subparsers.add_parser('compare', parents=parent_parsers)
-    subparser.add_argument('input',
+    subparser = subparsers.add_parser('compare', parents=parent_parsers,
+                                      help='Compare two schemas')
+    subparser.add_argument('prev_schema',
                            help='Input schema')
-    subparser.add_argument('expected', nargs='?',
+    subparser.add_argument('new_schema', nargs='?',
                            help='Expected schema')
 
 
@@ -208,15 +214,15 @@ def schema_to_sql(arg):
 
 
 def compare_schemas(arg):
-    """
+    """ Main entry point function to compare two schemas.
 
-    :param arg:
-    :return:
+    :param arg: dict
+    :return: diff: list of dicts
     """
     logger.info('=== Compare schemas')
-    input_schema = load_input_schema(arg)
-    expected_schema = load_input_schema(arg, opt='expected')
-    diff = compare_schemas_bases(input_schema, expected_schema)
+    prev_schema = load_input_schema(arg, opt='prev_schema')
+    new_schema = load_input_schema(arg, opt='new_schema')
+    diff = compare_schemas_bases(prev_schema, new_schema)
     return diff
 
 

--- a/pymongo_schema/export.py
+++ b/pymongo_schema/export.py
@@ -629,11 +629,11 @@ def write_output_dict(output_dict, arg):
                 '--without-counts': bool to display counts in output}
            additional field not fully managed yet --category schema | diff
     """
-    output_formats = arg['--format']
-    output_filename = arg['--output']
-    columns_to_get = arg.get('--columns', None)
-    without_counts = arg.get('--without-counts', False)
-    category = arg.get('--category', 'schema')
+    output_formats = arg['format']
+    output_filename = arg['output']
+    columns_to_get = arg.get('columns', None)
+    without_counts = arg.get('without-counts', False)
+    category = arg.get('category', 'schema')
 
     wrong_formats = set(output_formats) - {'tsv', 'xlsx', 'json', 'yaml', 'html', 'md'}
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -231,8 +231,8 @@ def test04_write_xlsx(schema_ex_df):
 def test06_write_output_dict_schema_md(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.md')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.md')
-    arg = {'format': ['md'], 'output': output, 'columns': columns}
-    write_output_dict(schema_ex_dict, arg)
+    arg = {'formats': ['md'], 'output': output, 'columns': columns}
+    transform_data_to_file(schema_ex_dict, **arg)
     assert filecmp.cmp(output, expected_file)
     os.remove(output)
 
@@ -240,8 +240,8 @@ def test06_write_output_dict_schema_md(schema_ex_dict, columns):
 def test07_write_output_dict_schema_html(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.html')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.html')
-    arg = {'format': ['html'], 'output': output, 'columns': columns}
-    write_output_dict(schema_ex_dict, arg)
+    arg = {'formats': ['html'], 'output': output, 'columns': columns}
+    transform_data_to_file(schema_ex_dict, **arg)
     with open(output) as out_fd, open(expected_file) as exp_fd:
         assert out_fd.read().replace(' ', '') == exp_fd.read().replace(' ', '')
     os.remove(output)
@@ -250,8 +250,8 @@ def test07_write_output_dict_schema_html(schema_ex_dict, columns):
 def test08_write_output_dict_schema_xlsx(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.xlsx')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.xlsx')
-    arg = {'format': ['xlsx'], 'output': output, 'columns': columns}
-    write_output_dict(schema_ex_dict, arg)
+    arg = {'formats': ['xlsx'], 'output': output, 'columns': columns}
+    transform_data_to_file(schema_ex_dict, **arg)
     res = [cell.value for row in load_workbook(output).active for cell in row]
     exp = [cell.value for row in load_workbook(expected_file).active for cell in row]
     assert res == exp
@@ -262,8 +262,8 @@ def test09_write_output_dict_schema_json_without_count(schema_ex_dict):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.json')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected',
                                  'data_dict_without_counts.json')
-    arg = {'format': ['json'], 'output': output, 'without-counts': True}
-    write_output_dict(schema_ex_dict, arg)
+    arg = {'formats': ['json'], 'output': output, 'without_counts': True}
+    transform_data_to_file(schema_ex_dict, **arg)
     with open(output) as out_fd, open(expected_file) as exp_fd:
         assert json.load(out_fd) == json.load(exp_fd)
     os.remove(output)
@@ -272,16 +272,16 @@ def test09_write_output_dict_schema_json_without_count(schema_ex_dict):
 def test10_write_output_dict_mapping_yaml(mapping_ex_dict):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_mapping.yaml')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'mapping.yaml')
-    arg = {'format': ['yaml'], 'output': output, 'columns': None, 'without-counts': True}
-    write_output_dict(mapping_ex_dict, arg)
+    arg = {'formats': ['yaml'], 'output': output, 'columns': None, 'without_counts': True}
+    transform_data_to_file(mapping_ex_dict, **arg)
     assert filecmp.cmp(output, expected_file)
     os.remove(output)
 
 
 def test11_write_output_dict_wrong_format(mapping_ex_dict):
-    arg = {'format': ['fake'], 'output': None, 'columns': None, 'without-counts': True}
+    arg = {'formats': ['fake'], 'output': None, 'columns': None, 'without_counts': True}
     with pytest.raises(ValueError):
-        write_output_dict(mapping_ex_dict, arg)
+        transform_data_to_file(mapping_ex_dict, **arg)
 
 
 def test12_write_output_dict_schema_non_ascii(columns):
@@ -293,11 +293,11 @@ def test12_write_output_dict_schema_non_ascii(columns):
         outputs[ext] = "{}.{}".format(base_output, ext)
     input_file = os.path.join(TEST_DIR, 'resources', 'input',
                               'test_schema_fr.json')
-    arg = {'format': extensions, 'output': base_output, 'columns':columns,
-           'without-counts': False}
+    arg = {'formats': extensions, 'output': base_output, 'columns':columns,
+           'without_counts': False}
     with open(input_file) as f:
         schema_fr = json.loads(f.read())
-    write_output_dict(schema_fr, arg)
+    transform_data_to_file(schema_fr, **arg)
     extensions.remove('xlsx')
     for ext in extensions:
         with open(outputs[ext]) as f:
@@ -336,8 +336,8 @@ def test14_schema_diff_to_df_long(long_diff, diff_columns):
 def test15_schema_diff_to_html(long_diff):
     output_file = os.path.join(TEST_DIR, 'output_test_diff.html')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'schema_diff.html')
-    arg = {'format': ['html'], 'output': output_file, 'category': 'diff'}
-    write_output_dict(long_diff, arg)
+    arg = {'formats': ['html'], 'output': output_file, 'category': 'diff'}
+    transform_data_to_file(long_diff, **arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
 
@@ -345,8 +345,8 @@ def test15_schema_diff_to_html(long_diff):
 def test16_schema_diff_to_md(long_diff):
     output_file = os.path.join(TEST_DIR, 'output_test_diff.md')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'schema_diff.md')
-    arg = {'format': ['md'], 'output': output_file, 'category': 'diff'}
-    write_output_dict(long_diff, arg)
+    arg = {'formats': ['md'], 'output': output_file, 'category': 'diff'}
+    transform_data_to_file(long_diff, **arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
 
@@ -354,7 +354,7 @@ def test16_schema_diff_to_md(long_diff):
 def test17_mapping_to_tsv(mapping_ex_dict):
     output_file = os.path.join(TEST_DIR, 'output_mapping.tsv')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'mapping.tsv')
-    arg = {'format': ['tsv'], 'output': output_file, 'category': 'mapping'}
-    write_output_dict(mapping_ex_dict, arg)
+    arg = {'formats': ['tsv'], 'output': output_file, 'category': 'mapping'}
+    transform_data_to_file(mapping_ex_dict, **arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -255,6 +255,11 @@ def test08_write_output_dict_schema_xlsx(schema_ex_dict, columns):
     res = [cell.value for row in load_workbook(output).active for cell in row]
     exp = [cell.value for row in load_workbook(expected_file).active for cell in row]
     assert res == exp
+    # test on existing file
+    transform_data_to_file(schema_ex_dict, **arg)
+    res = [cell.value for row in load_workbook(output).active for cell in row]
+    exp = [cell.value for row in load_workbook(expected_file).active for cell in row]
+    assert res == exp
     os.remove(output)
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -231,8 +231,7 @@ def test04_write_xlsx(schema_ex_df):
 def test06_write_output_dict_schema_md(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.md')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.md')
-    arg = {'--format': ['md'], '--output': output,
-           '--columns': " ".join(columns)}
+    arg = {'format': ['md'], 'output': output, 'columns': " ".join(columns)}
     write_output_dict(schema_ex_dict, arg)
     assert filecmp.cmp(output, expected_file)
     os.remove(output)
@@ -241,8 +240,7 @@ def test06_write_output_dict_schema_md(schema_ex_dict, columns):
 def test07_write_output_dict_schema_html(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.html')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.html')
-    arg = {'--format': ['html'], '--output': output,
-           '--columns': " ".join(columns)}
+    arg = {'format': ['html'], 'output': output, 'columns': " ".join(columns)}
     write_output_dict(schema_ex_dict, arg)
     with open(output) as out_fd, open(expected_file) as exp_fd:
         assert out_fd.read().replace(' ', '') == exp_fd.read().replace(' ', '')
@@ -252,8 +250,7 @@ def test07_write_output_dict_schema_html(schema_ex_dict, columns):
 def test08_write_output_dict_schema_xlsx(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.xlsx')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.xlsx')
-    arg = {'--format': ['xlsx'], '--output': output,
-           '--columns': " ".join(columns)}
+    arg = {'format': ['xlsx'], 'output': output, 'columns': " ".join(columns)}
     write_output_dict(schema_ex_dict, arg)
     res = [cell.value for row in load_workbook(output).active for cell in row]
     exp = [cell.value for row in load_workbook(expected_file).active for cell in row]
@@ -265,8 +262,7 @@ def test09_write_output_dict_schema_json_without_count(schema_ex_dict):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.json')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected',
                                  'data_dict_without_counts.json')
-    arg = {'--format': ['json'], '--output': output,
-           '--without-counts': True}
+    arg = {'format': ['json'], 'output': output, 'without-counts': True}
     write_output_dict(schema_ex_dict, arg)
     with open(output) as out_fd, open(expected_file) as exp_fd:
         assert json.load(out_fd) == json.load(exp_fd)
@@ -276,16 +272,14 @@ def test09_write_output_dict_schema_json_without_count(schema_ex_dict):
 def test10_write_output_dict_mapping_yaml(mapping_ex_dict):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_mapping.yaml')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'mapping.yaml')
-    arg = {'--format': ['yaml'], '--output': output,
-           '--columns': None, '--without-counts': True}
+    arg = {'format': ['yaml'], 'output': output, 'columns': None, 'without-counts': True}
     write_output_dict(mapping_ex_dict, arg)
     assert filecmp.cmp(output, expected_file)
     os.remove(output)
 
 
 def test11_write_output_dict_wrong_format(mapping_ex_dict):
-    arg = {'--format': ['fake'], '--output': None,
-           '--columns': None, '--without-counts': True}
+    arg = {'format': ['fake'], 'output': None, 'columns': None, 'without-counts': True}
     with pytest.raises(ValueError):
         write_output_dict(mapping_ex_dict, arg)
 
@@ -299,8 +293,8 @@ def test12_write_output_dict_schema_non_ascii(columns):
         outputs[ext] = "{}.{}".format(base_output, ext)
     input_file = os.path.join(TEST_DIR, 'resources', 'input',
                               'test_schema_fr.json')
-    arg = {'--format': extensions, '--output': base_output, '--columns': " ".join(columns),
-           '--without-counts': False}
+    arg = {'format': extensions, 'output': base_output, 'columns': " ".join(columns),
+           'without-counts': False}
     with open(input_file) as f:
         schema_fr = json.loads(f.read())
     write_output_dict(schema_fr, arg)
@@ -342,7 +336,7 @@ def test14_schema_diff_to_df_long(long_diff, diff_columns):
 def test15_schema_diff_to_html(long_diff):
     output_file = os.path.join(TEST_DIR, 'output_test_diff.html')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'schema_diff.html')
-    arg = {'--format': ['html'], '--output': output_file, '--category': 'diff'}
+    arg = {'format': ['html'], 'output': output_file, 'category': 'diff'}
     write_output_dict(long_diff, arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
@@ -351,7 +345,7 @@ def test15_schema_diff_to_html(long_diff):
 def test16_schema_diff_to_md(long_diff):
     output_file = os.path.join(TEST_DIR, 'output_test_diff.md')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'schema_diff.md')
-    arg = {'--format': ['md'], '--output': output_file, '--category': 'diff'}
+    arg = {'format': ['md'], 'output': output_file, 'category': 'diff'}
     write_output_dict(long_diff, arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
@@ -360,7 +354,7 @@ def test16_schema_diff_to_md(long_diff):
 def test17_mapping_to_tsv(mapping_ex_dict):
     output_file = os.path.join(TEST_DIR, 'output_mapping.tsv')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'mapping.tsv')
-    arg = {'--format': ['tsv'], '--output': output_file, '--category': 'mapping'}
+    arg = {'format': ['tsv'], 'output': output_file, 'category': 'mapping'}
     write_output_dict(mapping_ex_dict, arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -81,8 +81,8 @@ def schema_ex_df(schema_ex_dict, columns):
 
 
 def test00_field_compact_name():
-    assert _SchemaPreProcessing._field_compact_name('baz', None, 'foo.bar:') == ' .  : baz'
-    assert _SchemaPreProcessing._field_compact_name('baz', None, 'foo.foo.bar:') == ' .  .  : baz'
+    assert _SchemaPreProcessing._field_compact_name(None, 'baz', 'foo.bar:') == ' .  : baz'
+    assert _SchemaPreProcessing._field_compact_name(None, 'baz', 'foo.foo.bar:') == ' .  .  : baz'
 
 
 def test01_field_depth():
@@ -94,9 +94,9 @@ def test01_field_depth():
 
 
 def test02_field_type():
-    assert _SchemaPreProcessing._field_type(None, {'type': 'string'}, None) == 'string'
+    assert _SchemaPreProcessing._field_type({'type': 'string'}, None, None) == 'string'
     assert _SchemaPreProcessing._field_type(
-        None, {'type': 'ARRAY', 'array_type': 'string'}, None) == 'ARRAY(string)'
+        {'type': 'ARRAY', 'array_type': 'string'}, None, None) == 'ARRAY(string)'
 
 
 def test03_format_types_count():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -231,7 +231,7 @@ def test04_write_xlsx(schema_ex_df):
 def test06_write_output_dict_schema_md(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.md')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.md')
-    arg = {'format': ['md'], 'output': output, 'columns': " ".join(columns)}
+    arg = {'format': ['md'], 'output': output, 'columns': columns}
     write_output_dict(schema_ex_dict, arg)
     assert filecmp.cmp(output, expected_file)
     os.remove(output)
@@ -240,7 +240,7 @@ def test06_write_output_dict_schema_md(schema_ex_dict, columns):
 def test07_write_output_dict_schema_html(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.html')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.html')
-    arg = {'format': ['html'], 'output': output, 'columns': " ".join(columns)}
+    arg = {'format': ['html'], 'output': output, 'columns': columns}
     write_output_dict(schema_ex_dict, arg)
     with open(output) as out_fd, open(expected_file) as exp_fd:
         assert out_fd.read().replace(' ', '') == exp_fd.read().replace(' ', '')
@@ -250,7 +250,7 @@ def test07_write_output_dict_schema_html(schema_ex_dict, columns):
 def test08_write_output_dict_schema_xlsx(schema_ex_dict, columns):
     output = os.path.join(TEST_DIR, 'output_data_dict_from_schema.xlsx')
     expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict.xlsx')
-    arg = {'format': ['xlsx'], 'output': output, 'columns': " ".join(columns)}
+    arg = {'format': ['xlsx'], 'output': output, 'columns': columns}
     write_output_dict(schema_ex_dict, arg)
     res = [cell.value for row in load_workbook(output).active for cell in row]
     exp = [cell.value for row in load_workbook(expected_file).active for cell in row]
@@ -293,7 +293,7 @@ def test12_write_output_dict_schema_non_ascii(columns):
         outputs[ext] = "{}.{}".format(base_output, ext)
     input_file = os.path.join(TEST_DIR, 'resources', 'input',
                               'test_schema_fr.json')
-    arg = {'format': extensions, 'output': base_output, 'columns': " ".join(columns),
+    arg = {'format': extensions, 'output': base_output, 'columns':columns,
            'without-counts': False}
     with open(input_file) as f:
         schema_fr = json.loads(f.read())

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -64,7 +64,8 @@ def test02_transform():
 
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict')
     argv = ['transform', SCHEMA_FILE, '--output', base_output, '--columns',
-            'Field_compact_name Field_name Full_name Description Count Percentage Types_count',
+            'Field_compact_name', 'Field_name', 'Full_name', 'Description', 'Count', 'Percentage',
+            'Types_count',
             '--format'] + extensions
     main(argv)
 
@@ -91,7 +92,8 @@ def test03_transform_filter():
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict_filtered')
     argv = ['transform', SCHEMA_FILE, '--output', base_output,
             '--filter', namespace, '--columns',
-            'Field_compact_name Field_name Full_name Description Count Percentage Types_count',
+            'Field_compact_name', 'Field_name', 'Full_name', 'Description', 'Count', 'Percentage',
+            'Types_count',
             '--format'] + extensions
     main(argv)
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,7 +2,6 @@ import filecmp
 import json
 import os
 import pytest
-from itertools import chain
 
 from openpyxl import load_workbook
 from pymongo import MongoClient
@@ -22,7 +21,7 @@ def pymongo_client():
         yield conn
     finally:
         conn.close()
-        
+
 
 def test00_from_mongo_to_mapping(pymongo_client):
     with open(os.path.join(TEST_DIR, "resources", "input", "mapping.json")) as f:
@@ -64,9 +63,9 @@ def test02_transform():
         outputs[ext] = "{}.{}".format(base_output, ext)
 
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict')
-    argv = ['transform', '--input', SCHEMA_FILE, '--output', base_output, '--columns',
-            'Field_compact_name Field_name Full_name Description Count Percentage Types_count']
-    argv += chain.from_iterable([['--format', fmt] for fmt in extensions])
+    argv = ['transform', SCHEMA_FILE, '--output', base_output, '--columns',
+            'Field_compact_name Field_name Full_name Description Count Percentage Types_count',
+            '--format'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -90,10 +89,10 @@ def test03_transform_filter():
 
     namespace = os.path.join(TEST_DIR, 'resources', 'input', 'namespace.json')
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict_filtered')
-    argv = ['transform', '--input', SCHEMA_FILE, '--output', base_output,
+    argv = ['transform', SCHEMA_FILE, '--output', base_output,
             '--filter', namespace, '--columns',
-            'Field_compact_name Field_name Full_name Description Count Percentage Types_count']
-    argv += chain.from_iterable([['--format', fmt] for fmt in extensions])
+            'Field_compact_name Field_name Full_name Description Count Percentage Types_count',
+            '--format'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -116,8 +115,7 @@ def test04_transform_default_cols():
         outputs[ext] = "{}.{}".format(base_output, ext)
 
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict_default')
-    argv = ['transform', '--input', SCHEMA_FILE, '--output', base_output]
-    argv += chain.from_iterable([['--format', fmt] for fmt in extensions])
+    argv = ['transform', SCHEMA_FILE, '--output', base_output, '--format'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -136,7 +134,7 @@ def test05_tosql():
     output = os.path.join(TEST_DIR, "output_fctl_mapping.json")
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'mapping.json')
 
-    argv = ['tosql', '--input', SCHEMA_FILE, '--output', output]
+    argv = ['tosql', SCHEMA_FILE, '--output', output]
     main(argv)
 
     with open(output) as out_fd, open(exp) as exp_fd:
@@ -153,8 +151,7 @@ def test06_compare():
 
     exp = os.path.join(TEST_DIR, 'resources', 'functional', 'expected', 'diff')
     exp_schema = os.path.join(TEST_DIR, 'resources', 'input', 'test_schema2.json')
-    argv = ['compare', '--input', SCHEMA_FILE, '--output', base_output, '--expected', exp_schema]
-    argv += chain.from_iterable([['--format', fmt] for fmt in extensions])
+    argv = ['compare', SCHEMA_FILE, exp_schema, '--output', base_output, '--format'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -66,7 +66,7 @@ def test02_transform():
     argv = ['transform', SCHEMA_FILE, '--output', base_output, '--columns',
             'Field_compact_name', 'Field_name', 'Full_name', 'Description', 'Count', 'Percentage',
             'Types_count',
-            '--format'] + extensions
+            '--formats'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -94,7 +94,7 @@ def test03_transform_filter():
             '--filter', namespace, '--columns',
             'Field_compact_name', 'Field_name', 'Full_name', 'Description', 'Count', 'Percentage',
             'Types_count',
-            '--format'] + extensions
+            '--formats'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -117,7 +117,7 @@ def test04_transform_default_cols():
         outputs[ext] = "{}.{}".format(base_output, ext)
 
     exp = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict_default')
-    argv = ['transform', SCHEMA_FILE, '--output', base_output, '--format'] + extensions
+    argv = ['transform', SCHEMA_FILE, '--output', base_output, '--formats'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))
@@ -153,7 +153,7 @@ def test06_compare():
 
     exp = os.path.join(TEST_DIR, 'resources', 'functional', 'expected', 'diff')
     exp_schema = os.path.join(TEST_DIR, 'resources', 'input', 'test_schema2.json')
-    argv = ['compare', SCHEMA_FILE, exp_schema, '--output', base_output, '--format'] + extensions
+    argv = ['compare', SCHEMA_FILE, exp_schema, '--output', base_output, '--formats'] + extensions
     main(argv)
 
     assert filecmp.cmp(outputs['tsv'], "{}.tsv".format(exp))


### PR DESCRIPTION
This PR migrates from docopt to argparse to manage CLI.

It includes a few enhancements of the CLI:
- allow transform any category (previously just schema)
- allow output tosql at any format (previously just json)
- share arguments 'columns' and 'without_count' between all commands so output can be filtered in all cases
- columns to get are passed directly as list (not string)
- more command specific arguments denomination (command: input / expected -> prev_schema / new_schema)
- list options no longer need to be repeated (--format md --format json -> --format md json)

And in the export module:
- more consistently defined default columns
- entry point renamed (write_output_dict -> transform_data_to_file) and list expected arguments (not just arg)