### PR TITLE
Serial pk2

### DIFF
--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -56,7 +56,7 @@ Options:
 
     --without-counts            Remove counts information from json and yaml outputs
 
-    --quiet                     Set logging level to WARN on standard output
+    --quiet                     Remove logging on standard output
 
     -h, --help                  show this usage information
 
@@ -124,13 +124,9 @@ def preprocess_arg(arg):
 
 def initialize_logger(arg):
     """ Initialize logging to standard output, if not quiet."""
-    logger.setLevel(logging.INFO)
-    logger.addHandler(logging.NullHandler())
-    steam_handler = logging.StreamHandler()
-    logger.addHandler(steam_handler)
-
-    if arg['--quiet']:
-        logger.setLevel(logging.WARN)
+    if not arg['--quiet']:
+        stream_handler = logging.StreamHandler()
+        logger.addHandler(stream_handler)
 
 
 def extract_schema(arg):

--- a/pymongo_schema/tosql.py
+++ b/pymongo_schema/tosql.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Type of automatically generated primary keys
 # int in default mongo-connector-postgresql, string in pajachiet branch
-AUTO_GENERATED_PK_TYPE = 'TEXT'
+AUTO_GENERATED_PK_TYPE = 'SERIAL'
 
 
 def mongo_schema_to_mapping(mongo_schema):


### PR DESCRIPTION
Change type of auto-generated primary keys in sql mapping, to use with latest version of mongo-connector-postgresql

- change type of auto-generated primary keys, from 'TEXT' to 'SERIAL'
- change quiet mode to no output, to ease usage of pymongo-schema as a module from another python program