### PR TITLE
manage compatibility with schema extracted from code

### DIFF
--- a/pymongo_schema/tosql.py
+++ b/pymongo_schema/tosql.py
@@ -93,8 +93,14 @@ def add_object_to_mapping(object_schema, mapping, table_name, field_prefix=''):
                                                   mapping, table_name)
 
         elif mongo_type == 'OBJECT':
-            add_object_to_mapping(field_info['object'], mapping, table_name,
-                                  field_prefix=mongo_field_name + '.')
+            if 'object' in field_info:
+                add_object_to_mapping(field_info['object'], mapping, table_name,
+                                      field_prefix=mongo_field_name + '.')
+            else:   # can happen in extract from code (DictField)
+                logger.warning(
+                    "WARNING : 'JSON' SQL type is not managed yet. Field '%s' from table "
+                    "'%s' is skipped from the mapping.",
+                    mongo_field_name, table_name)
 
         else:
             comment = field_info.get('comment', '')

--- a/tests/resources/expected/data_dict_from_code.md
+++ b/tests/resources/expected/data_dict_from_code.md
@@ -1,0 +1,66 @@
+
+### Database: db1
+#### Collection: coll1 
+|Field_compact_name     |Field_name       |Default     |Field                     |Count     |
+|-----------------------|-----------------|------------|--------------------------|----------|
+|_id                    |_id              |            |ObjectIdField             |None      |
+|field1                 |field1           |            |ListField                 |None      |
+|field2                 |field2           |            |ReferenceField            |None      |
+|field3                 |field3           |            |DateTimeField             |None      |
+|field4                 |field4           |            |ListField                 |None      |
+| : subfield1           |subfield1        |            |StringField               |None      |
+| : subfield2           |subfield2        |            |ListField                 |None      |
+| :  : subsubfield1     |subsubfield1     |            |IntField                  |None      |
+| :  : subsubfield2     |subsubfield2     |            |BooleanField              |None      |
+| :  : subsubfield3     |subsubfield3     |            |IntField                  |None      |
+| :  : subsubfield4     |subsubfield4     |            |DateTimeField             |None      |
+|field5                 |field5           |            |AddressField              |None      |
+| . subfield1           |subfield1        |            |StringField               |None      |
+| . subfield2           |subfield2        |            |StringField               |None      |
+| . subfield3           |subfield3        |            |ListField                 |None      |
+| . subfield4           |subfield4        |            |ReferentialField          |None      |
+| .  . subsubfield1     |subsubfield1     |            |StringField               |None      |
+| .  . subsubfield2     |subsubfield2     |            |StringField               |None      |
+| . subfield5           |subfield5        |            |BooleanField              |None      |
+|field6                 |field6           |3           |IntField                  |None      |
+|field7                 |field7           |            |DateTimeField             |None      |
+|field8                 |field8           |            |EmailField                |None      |
+|field9                 |field9           |1           |IntField                  |None      |
+
+#### Collection: coll2 
+|Field_compact_name     |Field_name       |Default     |Field                     |Count     |
+|-----------------------|-----------------|------------|--------------------------|----------|
+|_id                    |_id              |            |ObjectIdField             |None      |
+|field1                 |field1           |            |DateTimeField             |None      |
+|field2                 |field2           |            |DictField                 |None      |
+|field3                 |field3           |            |StringField               |None      |
+|field4                 |field4           |            |ReferenceField            |None      |
+|field5                 |field5           |            |DateTimeField             |None      |
+
+#### Collection: coll3 
+|Field_compact_name     |Field_name       |Default     |Field                     |Count     |
+|-----------------------|-----------------|------------|--------------------------|----------|
+|_id                    |_id              |            |ObjectIdField             |None      |
+|field1                 |field1           |            |DateTimeField             |None      |
+|field2                 |field2           |            |GenericReferenceField     |None      |
+| . _cls                |_cls             |None        |None                      |None      |
+| . _ref                |_ref             |None        |None                      |None      |
+
+
+### Database: db2
+#### Collection: coll1 
+|Field_compact_name     |Field_name       |Default     |Field                     |Count     |
+|-----------------------|-----------------|------------|--------------------------|----------|
+|_id                    |_id              |            |ObjectIdField             |None      |
+|field1                 |field1           |            |DateTimeField             |None      |
+|field2                 |field2           |            |DictField                 |None      |
+|field3                 |field3           |            |StringField               |None      |
+|field4                 |field4           |            |ReferenceField            |None      |
+|field5                 |field5           |            |DateTimeField             |None      |
+
+#### Collection: coll2 
+|Field_compact_name     |Field_name       |Default     |Field                     |Count     |
+|-----------------------|-----------------|------------|--------------------------|----------|
+|_id                    |_id              |            |ObjectIdField             |None      |
+|field1                 |field1           |            |DateTimeField             |None      |
+

--- a/tests/resources/expected/mapping_from_code.json
+++ b/tests/resources/expected/mapping_from_code.json
@@ -1,0 +1,207 @@
+{
+  "db2": {
+    "coll1": {
+      "field1": {
+        "type": "TIMESTAMP",
+        "dest": "field1"
+      },
+      "pk": "_id",
+      "field5": {
+        "type": "TIMESTAMP",
+        "dest": "field5"
+      },
+      "_id": {
+        "type": "TEXT",
+        "dest": "_id"
+      },
+      "field3": {
+        "type": "TEXT",
+        "dest": "field3"
+      },
+      "field4": {
+        "type": "TEXT",
+        "dest": "field4"
+      }
+    },
+    "coll2": {
+      "_id": {
+        "type": "TEXT",
+        "dest": "_id"
+      },
+      "field1": {
+        "type": "TIMESTAMP",
+        "dest": "field1"
+      },
+      "pk": "_id"
+    }
+  },
+  "db1": {
+    "coll1": {
+      "field1": {
+        "valueField": "field1",
+        "type": "_ARRAY_OF_SCALARS",
+        "fk": "id_coll1",
+        "dest": "coll1__field1"
+      },
+      "pk": "_id",
+      "field5.subfield4.subsubfield1": {
+        "type": "TEXT",
+        "dest": "field5__subfield4__subsubfield1"
+      },
+      "field5.subfield2": {
+        "type": "TEXT",
+        "dest": "field5__subfield2"
+      },
+      "field3": {
+        "type": "TIMESTAMP",
+        "dest": "field3"
+      },
+      "field2": {
+        "type": "TEXT",
+        "dest": "field2"
+      },
+      "field6": {
+        "type": "INT",
+        "dest": "field6"
+      },
+      "field5.subfield5": {
+        "type": "BOOLEAN",
+        "dest": "field5__subfield5"
+      },
+      "field9": {
+        "type": "INT",
+        "dest": "field9"
+      },
+      "field7": {
+        "type": "TIMESTAMP",
+        "dest": "field7"
+      },
+      "field5.subfield3": {
+        "valueField": "subfield3",
+        "type": "_ARRAY_OF_SCALARS",
+        "fk": "id_coll1",
+        "dest": "coll1__field5__subfield3"
+      },
+      "_id": {
+        "type": "TEXT",
+        "dest": "_id"
+      },
+      "field5.subfield1": {
+        "type": "TEXT",
+        "dest": "field5__subfield1"
+      },
+      "field4": {
+        "type": "_ARRAY",
+        "fk": "id_coll1",
+        "dest": "coll1__field4"
+      },
+      "field5.subfield4.subsubfield2": {
+        "type": "TEXT",
+        "dest": "field5__subfield4__subsubfield2"
+      },
+      "field8": {
+        "type": "TEXT",
+        "dest": "field8"
+      }
+    },
+    "coll2": {
+      "field1": {
+        "type": "TIMESTAMP",
+        "dest": "field1"
+      },
+      "pk": "_id",
+      "field5": {
+        "type": "TIMESTAMP",
+        "dest": "field5"
+      },
+      "_id": {
+        "type": "TEXT",
+        "dest": "_id"
+      },
+      "field3": {
+        "type": "TEXT",
+        "dest": "field3"
+      },
+      "field4": {
+        "type": "TEXT",
+        "dest": "field4"
+      }
+    },
+    "coll1__field4__subfield2": {
+      "subsubfield4": {
+        "type": "TIMESTAMP",
+        "dest": "subsubfield4"
+      },
+      "subsubfield2": {
+        "type": "BOOLEAN",
+        "dest": "subsubfield2"
+      },
+      "pk": "id",
+      "id_coll1__field4": {
+        "type": "SERIAL"
+      },
+      "subsubfield1": {
+        "type": "INT",
+        "dest": "subsubfield1"
+      },
+      "subsubfield3": {
+        "type": "INT",
+        "dest": "subsubfield3"
+      }
+    },
+    "coll1__field4": {
+      "subfield1": {
+        "type": "TEXT",
+        "dest": "subfield1"
+      },
+      "subfield2": {
+        "type": "_ARRAY",
+        "fk": "id_coll1__field4",
+        "dest": "coll1__field4__subfield2"
+      },
+      "id_coll1": {
+        "type": "TEXT"
+      },
+      "pk": "id"
+    },
+    "coll3": {
+      "_id": {
+        "type": "TEXT",
+        "dest": "_id"
+      },
+      "field2._ref": {
+        "type": "TEXT",
+        "dest": "field2___ref"
+      },
+      "field1": {
+        "type": "TIMESTAMP",
+        "dest": "field1"
+      },
+      "pk": "_id",
+      "field2._cls": {
+        "type": "TEXT",
+        "dest": "field2___cls"
+      }
+    },
+    "coll1__field1": {
+      "id_coll1": {
+        "type": "TEXT"
+      },
+      "pk": "id",
+      "field1": {
+        "type": "TEXT",
+        "dest": "field1"
+      }
+    },
+    "coll1__field5__subfield3": {
+      "subfield3": {
+        "type": "REAL",
+        "dest": "subfield3"
+      },
+      "id_coll1": {
+        "type": "TEXT"
+      },
+      "pk": "id"
+    }
+  }
+}

--- a/tests/resources/input/schema_from_code.json
+++ b/tests/resources/input/schema_from_code.json
@@ -1,0 +1,446 @@
+{
+  "db1": {
+    "coll1": {
+      "object": {
+        "field1": {
+          "array_type": "oid",
+          "default": "",
+          "type": "ARRAY",
+          "sensitive": false,
+          "required": true,
+          "field": "ListField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field2": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": true,
+          "field": "ReferenceField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field3": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field4": {
+          "array_type": "OBJECT",
+          "object": {
+            "subfield1": {
+              "default": "",
+              "type": "string",
+              "sensitive": false,
+              "required": true,
+              "field": "StringField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            },
+            "subfield2": {
+              "array_type": "OBJECT",
+              "object": {
+                "subsubfield1": {
+                  "default": "",
+                  "type": "integer",
+                  "sensitive": false,
+                  "required": false,
+                  "field": "IntField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": true
+                },
+                "subsubfield2": {
+                  "default": "",
+                  "type": "boolean",
+                  "sensitive": false,
+                  "required": true,
+                  "field": "BooleanField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": true
+                },
+                "subsubfield3": {
+                  "default": "",
+                  "type": "integer",
+                  "sensitive": false,
+                  "required": false,
+                  "field": "IntField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": true
+                },
+                "subsubfield4": {
+                  "default": "",
+                  "type": "date",
+                  "sensitive": false,
+                  "required": true,
+                  "field": "DateTimeField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": false
+                }
+              },
+              "default": "",
+              "type": "ARRAY",
+              "sensitive": false,
+              "required": false,
+              "field": "ListField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            }
+          },
+          "default": "",
+          "type": "ARRAY",
+          "sensitive": false,
+          "required": false,
+          "field": "ListField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field5": {
+          "object": {
+            "subfield1": {
+              "default": "",
+              "type": "string",
+              "sensitive": false,
+              "required": false,
+              "field": "StringField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            },
+            "subfield2": {
+              "default": "",
+              "type": "string",
+              "sensitive": false,
+              "required": false,
+              "field": "StringField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            },
+            "subfield3": {
+              "array_type": "float",
+              "default": "",
+              "type": "ARRAY",
+              "sensitive": false,
+              "required": false,
+              "field": "ListField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            },
+            "subfield4": {
+              "object": {
+                "subsubfield1": {
+                  "default": "",
+                  "type": "string",
+                  "sensitive": false,
+                  "required": true,
+                  "field": "StringField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": false
+                },
+                "subsubfield2": {
+                  "default": "",
+                  "type": "string",
+                  "sensitive": false,
+                  "required": false,
+                  "field": "StringField",
+                  "description": null,
+                  "usage name": null,
+                  "is_num": false
+                }
+              },
+              "default": "",
+              "type": "OBJECT",
+              "sensitive": false,
+              "required": false,
+              "field": "ReferentialField",
+              "description": null,
+              "usage name": null,
+              "is_num": false
+            },
+            "subfield5": {
+              "default": "",
+              "type": "boolean",
+              "sensitive": false,
+              "required": false,
+              "field": "BooleanField",
+              "description": null,
+              "usage name": null,
+              "is_num": true
+            }
+          },
+          "default": "",
+          "type": "OBJECT",
+          "sensitive": false,
+          "required": true,
+          "field": "AddressField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field6": {
+          "default": 3,
+          "type": "integer",
+          "sensitive": false,
+          "required": true,
+          "field": "IntField",
+          "description": null,
+          "usage name": null,
+          "is_num": true
+        },
+        "field7": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": "Date de creation",
+          "is_num": false
+        },
+        "field8": {
+          "default": "",
+          "type": "string",
+          "sensitive": false,
+          "required": false,
+          "field": "EmailField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "_id": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": false,
+          "field": "ObjectIdField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field9": {
+          "default": 1,
+          "type": "integer",
+          "sensitive": false,
+          "required": true,
+          "field": "IntField",
+          "description": null,
+          "usage name": "Some usage name",
+          "is_num": true
+        }
+      }
+    },
+    "coll2": {
+      "object": {
+        "field1": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field2": {
+          "default": "",
+          "type": "OBJECT",
+          "sensitive": false,
+          "required": false,
+          "field": "DictField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field3": {
+          "default": "",
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "field": "StringField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "_id": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": false,
+          "field": "ObjectIdField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field4": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": true,
+          "field": "ReferenceField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field5": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": "A simple description",
+          "is_num": false
+        }
+      }
+    },
+    "coll3": {
+      "object": {
+        "field1": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": "Date de creation",
+          "is_num": false
+        },
+        "field2": {
+          "object": {
+            "_cls": {
+              "type": "string"
+            },
+            "_ref": {
+              "type": "dbref"
+            }
+          },
+          "default": "",
+          "type": "OBJECT",
+          "sensitive": false,
+          "required": false,
+          "field": "GenericReferenceField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "_id": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": false,
+          "field": "ObjectIdField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        }
+      }
+    }
+  },
+  "db2": {
+    "coll1": {
+      "object": {
+        "field1": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field2": {
+          "default": "",
+          "type": "OBJECT",
+          "sensitive": false,
+          "required": false,
+          "field": "DictField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field3": {
+          "default": "",
+          "type": "string",
+          "sensitive": false,
+          "required": true,
+          "field": "StringField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "_id": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": false,
+          "field": "ObjectIdField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field4": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": true,
+          "field": "ReferenceField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "field5": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": "A simple description",
+          "is_num": false
+        }
+      }
+    },
+    "coll2": {
+      "object": {
+        "field1": {
+          "default": "",
+          "type": "date",
+          "sensitive": false,
+          "required": false,
+          "field": "DateTimeField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        },
+        "_id": {
+          "default": "",
+          "type": "oid",
+          "sensitive": false,
+          "required": false,
+          "field": "ObjectIdField",
+          "description": null,
+          "usage name": null,
+          "is_num": false
+        }
+      }
+    }
+  }
+}

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -363,3 +363,15 @@ def test17_mapping_to_tsv(mapping_ex_dict):
     transform_data_to_file(mapping_ex_dict, **arg)
     assert filecmp.cmp(output_file, expected_file)
     os.remove(output_file)
+
+
+def test18_schema_from_code():
+    with open(os.path.join(TEST_DIR, 'resources', 'input', 'schema_from_code.json')) as f:
+        schema = json.load(f)
+    output_file = os.path.join(TEST_DIR, 'output_data_dict_from_code.md')
+    expected_file = os.path.join(TEST_DIR, 'resources', 'expected', 'data_dict_from_code.md')
+    arg = {'formats': ['md'], 'output': output_file,
+           'columns': ['Field_compact_name', 'Field_name', 'Default', 'Field', 'Count']}
+    transform_data_to_file(schema, **arg)
+    assert filecmp.cmp(output_file, expected_file)
+    os.remove(output_file)

--- a/tests/test_tosql.py
+++ b/tests/test_tosql.py
@@ -1,6 +1,10 @@
+import json
+import os
 import pytest
 
 from pymongo_schema.tosql import *
+
+TEST_DIR = os.path.dirname(__file__)
 
 
 @pytest.fixture(scope='module')
@@ -36,7 +40,6 @@ def long_schema():
                                                        'array_type': 'string',
                                                        'array_types_count': {'string': 93463,
                                                                              'null': 738}}}}}}
-
 
 
 def test00_init_collection_mapping_simple(simple_schema):
@@ -163,3 +166,11 @@ def test10_mongo_schema_to_mapping_long(simple_schema, long_schema):
                    'coll1': {'pk': '_id', '_id': {'dest': '_id', 'type': 'TEXT'},
                              'field': {'dest': 'field', 'type': 'TEXT'}}}}
     assert res == exp
+
+
+def test11_schema_from_code_to_mapping():
+    with open(os.path.join(TEST_DIR, 'resources', 'input', 'schema_from_code.json')) as f:
+        schema = json.load(f)
+    with open(os.path.join(TEST_DIR, 'resources', 'expected', 'mapping_from_code.json')) as f:
+        exp_mapping = json.load(f)
+    assert mongo_schema_to_mapping(schema) == exp_mapping


### PR DESCRIPTION
Allow modules (export, tosql) to manage schema extracted from code (instead of extract from database). 

The main difference is that there are no count fields in the schema.
Also, there is one specific `Field` (`DictField`) that has to be managed differently as it is an undefined schema object (it has `OBJECT` type but no `object` key). This should match a `JSON` field in PostgreSQL but since it is not correctly managed by the doc manager (creates a `JSON` column but does not copy data), it is removed from mapping.