### PR TITLE
speed up schema extraction with field trade-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage:
     python -m pymongo_schema extract -h
     usage:  [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--port PORT] [--host HOST]
                  [-d [DATABASES [DATABASES ...]]] [-c [COLLECTIONS [COLLECTIONS ...]]]
-                 [--columns COLUMNS [COLUMNS ...]] [--without-counts]
+                 [--columns COLUMNS [COLUMNS ...]] [--size SIZE] [--without-counts]
                  
     python -m pymongo_schema transform -h
     usage: [-h] [-f [FORMATS [FORMATS ...]]] [-o OUTPUT] [--category CATEGORY] [-n FILTER]
@@ -182,6 +182,10 @@ Map this schema to a relational mapping
 **extract:** Extract the schema for collections `test_collection_1` and `test_collection_2` from `test_db` and write it into `mongo_schema.html` and `mongo_schema.json` files
 ```shell
     python -m pymongo_schema extract --databases test_db --collections test_collection_1 test_collection_2 --output mongo_schema --format html json
+```
+**extract:** Extract the schema for collection `test_collection_1` with only 1000 random rows scanned and write it into `mongo_schema.html` files
+```shell
+    python -m pymongo_schema extract --collections test_collection_1 --size 1000 --output mongo_schema --format html
 ```
 **transform:** Filter extracted schema (`mongo_schema.json`) using `namespace.json` file and write output into `mongo_schema_filtered.html`, `mongo_schema_filtered.csv` and `mongo_schema_filtered.json` files
 ```shell

--- a/pymongo_schema/__main__.py
+++ b/pymongo_schema/__main__.py
@@ -34,6 +34,9 @@ def add_subparser_extract(subparsers, parent_parsers):
     subparser.add_argument('-c', '--collections', nargs='*',
                            help='Only analyze those collections. By default analyze all '
                                 'collections in each database')
+    subparser.add_argument('--size', default=0, type=int,
+                           help='Only analyze limited rows with random. By default analyze all '
+                                'rows in each collections')
     subparser.add_argument('--port', default=27017, type=int,
                            help='Port to connect to MongoDB [default: 27017]')
     subparser.add_argument('--host', default='localhost',
@@ -182,7 +185,8 @@ def extract_schema(args):
     
     mongo_schema = extract_pymongo_client_schema(client,
                                                  database_names=args.databases,
-                                                 collection_names=args.collections)
+                                                 collection_names=args.collections,
+                                                 sample_size=args.size)
 
     logger.info('--- MongoDB schema analysis took %.2f s', time() - start_time)
     return mongo_schema

--- a/pymongo_schema/extract.py
+++ b/pymongo_schema/extract.py
@@ -129,12 +129,13 @@ def extract_collection_schema(pymongo_collection, sample_size=0):
         documents = pymongo_collection.aggregate([{'$sample': {'size': sample_size}}], allowDiskUse=True)
     else:
         documents = pymongo_collection.find({})
+    scan_count = sample_size or n
     i = 0
     for document in documents:
         add_document_to_object_schema(document, collection_schema['object'])
         i += 1
-        if i % 10 ** 5 == 0 or i == n:
-            logger.info('   scanned %s documents out of %s (%.2f %%)', i, n, (100. * i) / n)
+        if i % 10 ** 5 == 0 or i == scan_count:
+            logger.info('   scanned %s documents out of %s (%.2f %%)', i, scan_count, (100. * i) / scan_count)
 
     post_process_schema(collection_schema)
     collection_schema = recursive_default_to_regular_dict(collection_schema)

--- a/pymongo_schema/extract.py
+++ b/pymongo_schema/extract.py
@@ -120,13 +120,9 @@ def extract_collection_schema(pymongo_collection):
     }
 
     n = pymongo_collection.count()
-    i = 0
-    for document in pymongo_collection.find({}):
-        collection_schema['count'] += 1
+    collection_schema['count'] = n
+    for document in pymongo_collection.aggregate([{'$sample': {'size': 1000}}], allowDiskUse=True):
         add_document_to_object_schema(document, collection_schema['object'])
-        i += 1
-        if i % 10 ** 5 == 0 or i == n:
-            logger.info('   scanned %s documents out of %s (%.2f %%)', i, n, (100. * i) / n)
 
     post_process_schema(collection_schema)
     collection_schema = recursive_default_to_regular_dict(collection_schema)


### PR DESCRIPTION
It's too slow for big collection, and timeout always happen.
So, replace scan all rows with only 1000 random samples to speed up extraction.
