### PR TITLE
upgrade to pymongo 4.x

### DIFF
--- a/pymongo_schema/extract.py
+++ b/pymongo_schema/extract.py
@@ -66,7 +66,7 @@ def extract_pymongo_client_schema(pymongo_client, database_names=None, collectio
         database_names = [database_names]
 
     if database_names is None:
-        database_names = pymongo_client.database_names()
+        database_names = pymongo_client.list_database_names()
         database_names.remove('admin')
         database_names.remove('local')
 
@@ -92,7 +92,7 @@ def extract_database_schema(pymongo_database, collection_names=None, sample_size
     if isinstance(collection_names, basestring):
         collection_names = [collection_names]
 
-    database_collections = pymongo_database.collection_names(include_system_collections=False)
+    database_collections = pymongo_database.list_collection_names()
     if collection_names is None:
         collection_names = database_collections
     else:
@@ -123,7 +123,7 @@ def extract_collection_schema(pymongo_collection, sample_size=0):
         "object": init_empty_object_schema()
     }
 
-    n = pymongo_collection.count()
+    n = pymongo_collection.estimated_document_count()
     collection_schema['count'] = n
     if sample_size:
         documents = pymongo_collection.aggregate([{'$sample': {'size': sample_size}}], allowDiskUse=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymongo
+pymongo>=4.0.0
 pyyaml
 docopt
 git+https://github.com/etetoolkit/ete.git
@@ -8,6 +8,6 @@ xlsxwriter
 openpyxl
 python-coveralls
 jinja2
-future==0.16.0
-pytest==3.2.1
-pytest-cov==2.5.1
+future>=0.18.0
+pytest>=7.0.0
+pytest-cov>=3.00

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@
 from setuptools import setup
 
 setup(name='pymongo-schema',
-      version='0.3',
+      version='0.4',
       description='A schema analyser for MongoDB written in Python',
       packages=['pymongo_schema'],
       install_requires=[
-          'pymongo',
+          'pymongo>=4.0.0',
           'pyyaml',
           'docopt',
           'ete3',
@@ -17,7 +17,7 @@ setup(name='pymongo-schema',
           'xlsxwriter',
           'openpyxl',
           'jinja2',
-          'future==0.16.0',
+          'future>=0.18.0',
           'scipy'
       ],
       dependency_links=[

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -110,7 +110,7 @@ def test12_summarize_types_long():
 def test_extract_schema(pymongo_client):
     schema_file_path = os.path.join(TEST_DIR, 'resources', 'expected', 'schema.json')
     with open(schema_file_path) as data_file:
-        mongo_schema_expected = json.load(data_file, encoding='utf-8')
+        mongo_schema_expected = json.load(data_file)
 
     mongo_schema_got = extract_pymongo_client_schema(pymongo_client,
                                                      database_names='test_db',


### PR DESCRIPTION
Hi! Found this tool useful

Had somewhat actualized it to support pymongo>=4.x (referring to the [official migration guide](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html)) and recent python versions.

Tests are successfully passing on python 3.6 - 3.10
some pytest logs can be found here:
- [3.6.log](https://github.com/pajachiet/pymongo-schema/files/9280382/3.6.log)
- [3.7.log](https://github.com/pajachiet/pymongo-schema/files/9280362/3.7.log)
- [3.8.log](https://github.com/pajachiet/pymongo-schema/files/9280363/3.8.log)
- [3.9.log](https://github.com/pajachiet/pymongo-schema/files/9280364/3.9.log)
- [3.10.log](https://github.com/pajachiet/pymongo-schema/files/9280365/3.10.log)
